### PR TITLE
Fix Sync() error on Windows

### DIFF
--- a/cmd/geoipupdate/main.go
+++ b/cmd/geoipupdate/main.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -422,8 +423,10 @@ func writeAndCheck(
 		}
 	}()
 
-	if err := dh.Sync(); err != nil {
-		return errors.Wrap(err, "error syncing database directory")
+	if runtime.GOOS != "windows" {
+		if err := dh.Sync(); err != nil {
+			return errors.Wrap(err, "error syncing database directory")
+		}
 	}
 
 	if verbose {


### PR DESCRIPTION
As noted in this issue (https://github.com/maxmind/geoipupdate/issues/26), fsync is not supported on Windows when using a directory.

Simple fix is to skip the Sync test when on Windows.