### PR TITLE
Make database.Writer easier to implement

### DIFF
--- a/pkg/geoipupdate/database/http_reader.go
+++ b/pkg/geoipupdate/database/http_reader.go
@@ -46,15 +46,12 @@ func (reader *HTTPDatabaseReader) Get(destination Writer, editionID string) erro
 			log.Println(err)
 		}
 	}()
-	lastHash, err := destination.GetHash()
-	if err != nil {
-		return errors.Wrap(err, "unable to get previous hash")
-	}
+
 	maxMindURL := fmt.Sprintf(
 		"%s/geoip/databases/%s/update?db_md5=%s",
 		reader.url,
 		url.PathEscape(editionID),
-		url.QueryEscape(lastHash),
+		url.QueryEscape(destination.GetHash()),
 	)
 
 	req, err := http.NewRequest(http.MethodGet, maxMindURL, nil)

--- a/pkg/geoipupdate/database/local_file_writer.go
+++ b/pkg/geoipupdate/database/local_file_writer.go
@@ -38,10 +38,10 @@ func NewLocalFileDatabaseWriter(filePath string, lockFilePath string, verbose bo
 	}
 
 	var err error
-	if err = dbWriter.createOldMD5Hash(); err != nil {
+	if dbWriter.lock, err = CreateLockFile(lockFilePath, verbose); err != nil {
 		return nil, err
 	}
-	if dbWriter.lock, err = CreateLockFile(lockFilePath, verbose); err != nil {
+	if err = dbWriter.createOldMD5Hash(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/geoipupdate/database/writer.go
+++ b/pkg/geoipupdate/database/writer.go
@@ -1,15 +1,47 @@
 package database
 
 import (
+	"github.com/gofrs/flock"
+	"github.com/pkg/errors"
 	"io"
+	"log"
+	"os"
+	"path/filepath"
 	"time"
 )
 
-// Writer provides an interface for writing the database to a target location.
+//ZeroMD5 is the default value provided as an MD5 hash for a non-existent database
+const ZeroMD5 = "00000000000000000000000000000000"
+
+//Writer provides an interface for writing MaxMind a database to a target location
 type Writer interface {
 	io.WriteCloser
 	ValidHash(expectedHash string) error
-	GetHash() (string, error)
+	GetHash() string
 	SetFileModificationTime(lastModified time.Time) error
 	Commit() error
+}
+
+// CreateLockFile takes the provided filePath and lockFilePath name to create an flock.  All output errors are wrapped
+//	in more detailed messages for debugging
+func CreateLockFile(lockFilePath string, verbose bool) (*flock.Flock, error) {
+	fi, err := os.Stat(filepath.Dir(lockFilePath))
+	if err != nil {
+		return nil, errors.Wrap(err, "database directory is not available")
+	}
+	if !fi.IsDir() {
+		return nil, errors.New("database directory is not a directory")
+	}
+	lock := flock.New(lockFilePath)
+	ok, err := lock.TryLock()
+	if err != nil {
+		return nil, errors.Wrap(err, "error acquiring a lock")
+	}
+	if !ok {
+		return nil, errors.Errorf("could not acquire lock on %s", lockFilePath)
+	}
+	if verbose {
+		log.Printf("Acquired lock file lock (%s)", lockFilePath)
+	}
+	return lock, nil
 }

--- a/pkg/geoipupdate/database/writer_test.go
+++ b/pkg/geoipupdate/database/writer_test.go
@@ -23,7 +23,7 @@ func TestCreateLockFile(t *testing.T) {
 		{
 			Description:   "Database should fail to build with bad file path",
 			LockFilename:  "bad/file/path.geoipupdate.lock",
-			ExpectedError: `database directory is not available.*no such file or directory`,
+			ExpectedError: `database directory is not available`,
 		},
 	}
 

--- a/pkg/geoipupdate/database/writer_test.go
+++ b/pkg/geoipupdate/database/writer_test.go
@@ -9,25 +9,21 @@ import (
 	"testing"
 )
 
-func TestNewDatabaseWriter(t *testing.T) {
-
+func TestCreateLockFile(t *testing.T) {
 	tests := []struct {
 		Description   string
-		FilePath      string
-		LockFilePath  string
+		LockFilename  string
 		ExpectedError string
 	}{
 		{
 			Description:   "Database shouldn't have errors with good file paths",
-			FilePath:      "GeoIP2-City.mmdb",
-			LockFilePath:  ".geoipupdate.lock",
+			LockFilename:  ".geoipupdate.lock",
 			ExpectedError: "",
 		},
 		{
 			Description:   "Database should fail to build with bad file path",
-			FilePath:      "GeoIP2-City.mmdb",
-			LockFilePath:  "bad/file/path.geoipupdate.lock",
-			ExpectedError: `database directory is not available`,
+			LockFilename:  "bad/file/path.geoipupdate.lock",
+			ExpectedError: `database directory is not available.*no such file or directory`,
 		},
 	}
 
@@ -37,8 +33,7 @@ func TestNewDatabaseWriter(t *testing.T) {
 		err = os.RemoveAll(tempDir)
 		require.NoError(t, err)
 		t.Run(test.Description, func(t *testing.T) {
-			_, err = NewLocalFileDatabaseWriter(filepath.Join(tempDir, test.FilePath),
-				filepath.Join(tempDir, test.LockFilePath), false)
+			_, err := CreateLockFile(filepath.Join(tempDir, test.LockFilename), false)
 			if err != nil {
 				// regex because some errors have filenames.
 				assert.Regexp(t, test.ExpectedError, err.Error(), test.Description)
@@ -47,5 +42,4 @@ func TestNewDatabaseWriter(t *testing.T) {
 			}
 		})
 	}
-
 }


### PR DESCRIPTION
Centralized file locking mechanism and changed the `GetHash()` function to make the Writer interface easier to extend.