### PR TITLE
Respect the default config and database path variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 4.1.5
+
+* Respect the defaultConfigFile and defaultDatabaseDirectory variables in
+  the main package again. They were ignored in 4.1.0 through 4.1.4. If not
+  specified, these GitHub and PPA releases looked for the config in
+  /usr/local/etc/GeoIP.conf and the database directory in
+  /usr/local/share/GeoIP, where these should have been /etc/GeoIP.conf and
+  /usr/share/GeoIP.
+
 ## 4.1.4 (2019-11-07)
 
 * Re-release of 4.1.3 as two commits were missing. No changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@
 
 * Respect the defaultConfigFile and defaultDatabaseDirectory variables in
   the main package again. They were ignored in 4.1.0 through 4.1.4. If not
-  specified, these GitHub and PPA releases looked for the config in
-  /usr/local/etc/GeoIP.conf and the database directory in
-  /usr/local/share/GeoIP, where these should have been /etc/GeoIP.conf and
-  /usr/share/GeoIP.
+  specified, the GitHub and PPA releases for these versions used the config
+  /usr/local/etc/GeoIP.conf instead of /etc/GeoIP.conf and the database
+  directory /usr/local/share/GeoIP instead of /usr/share/GeoIP.
 
 ## 4.1.4 (2019-11-07)
 

--- a/cmd/geoipupdate/args.go
+++ b/cmd/geoipupdate/args.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/maxmind/geoipupdate/pkg/geoipupdate"
 	"log"
 	"os"
 
@@ -20,7 +19,7 @@ func getArgs() *Args {
 	configFile := flag.StringP(
 		"config-file",
 		"f",
-		geoipupdate.DefaultConfigFile,
+		defaultConfigFile,
 		"Configuration file",
 	)
 	databaseDirectory := flag.StringP(

--- a/cmd/geoipupdate/main.go
+++ b/cmd/geoipupdate/main.go
@@ -10,11 +10,21 @@ import (
 	"path/filepath"
 )
 
-// version is the program's version number.
-var version = "unknown"
+var (
+	version                  = "unknown"
+	defaultConfigFile        string
+	defaultDatabaseDirectory string
+)
 
 func main() {
 	log.SetFlags(0)
+
+	if defaultConfigFile == "" {
+		defaultConfigFile = geoipupdate.DefaultConfigFile
+	}
+	if defaultDatabaseDirectory == "" {
+		defaultDatabaseDirectory = geoipupdate.DefaultDatabaseDirectory
+	}
 
 	args := getArgs()
 	fatalLogger := func(message string, err error) {
@@ -26,7 +36,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	config, err := geoipupdate.NewConfig(args.ConfigFile, geoipupdate.DefaultDatabaseDirectory, args.DatabaseDirectory, args.Verbose)
+	config, err := geoipupdate.NewConfig(args.ConfigFile, defaultDatabaseDirectory, args.DatabaseDirectory, args.Verbose)
 	if err != nil {
 		fatalLogger("error loading configuration file", err)
 	}


### PR DESCRIPTION
We set these in the Makefile and goreleaser configs, but as of the move
of them to the package, they weren't respected. This leads to ignoring
them when we shouldn't.