### PR TITLE
Add more platforms

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,12 +13,25 @@ archives:
 builds:
   - main: './cmd/geoipupdate'
     binary: 'geoipupdate'
-    goarch:
-      - '386'
-      - 'amd64'
     goos:
       - 'darwin'
       - 'linux'
+      - 'freebsd'
+    goarch:
+      - '386'
+      - 'amd64'
+      - 'arm'
+      - 'arm64'
+      - 'ppc64le'
+      - 's390x'
+    goarm:
+      - '6'
+      - '7'
+    ignore:
+      - goos: 'freebsd'
+        goarch: 'arm'
+      - goos: 'freebsd'
+        goarch: 'arm64'
     hooks:
       post: 'make data BUILDDIR=.'
 checksum:


### PR DESCRIPTION
This will allow to use geoipupdate on Raspberry for example and also on multi-platform Docker images.