### PR TITLE
Fixed error checking in Close method of LocalFileDatabaseWriter

### DIFF
--- a/pkg/geoipupdate/database/local_file_writer.go
+++ b/pkg/geoipupdate/database/local_file_writer.go
@@ -94,10 +94,10 @@ func (writer *LocalFileDatabaseWriter) Write(p []byte) (int, error) {
 
 //Close closes the temporary file and releases the file lock
 func (writer *LocalFileDatabaseWriter) Close() error {
-	if err := writer.temporaryFile.Close(); err != nil && errors.Cause(err) == os.ErrClosed {
+	if err := writer.temporaryFile.Close(); err != nil && errors.Cause(err) != os.ErrClosed {
 		return errors.Wrap(err, "error closing temporary file")
 	}
-	if err := os.Remove(writer.temporaryFile.Name()); err != nil && errors.Cause(err) == os.ErrNotExist {
+	if err := os.Remove(writer.temporaryFile.Name()); err != nil && errors.Cause(err) != os.ErrNotExist {
 		return errors.Wrap(err, "error removing temporary file")
 	}
 	if err := writer.lock.Unlock(); err != nil {


### PR DESCRIPTION
Since during Commit we are closing and moving file, I guess we have typo in error checking of Close method