### PR TITLE
Update pkg/errors and fix Close error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ os:
   - windows
 
 go:
-  - "1.12.x"
   - "1.13.x"
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ go:
   - "1.12.x"
   - "1.13.x"
 
-install:
-  - go get -t ./...
-
 before_script:
   - |
     if [[ $TRAVIS_GO_VERSION == '1.13.x' && $TRAVIS_OS_NAME == 'linux' ]]; then
@@ -24,3 +21,6 @@ script:
     if [[ $TRAVIS_GO_VERSION == '1.13.x' && $TRAVIS_OS_NAME == 'linux' ]]; then
       golangci-lint run
     fi
+
+env:
+  - GO111MODULE=on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+* The minimum Go version is now 1.13.
 * A valid account ID and license key combination is now required for database
   downloads, so those configuration options are now required.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 * The minimum Go version is now 1.13.
 * A valid account ID and license key combination is now required for database
   downloads, so those configuration options are now required.
+* The error handling when closing a local database file would previously
+  ignore errors and, upon upgrading to `github.com/pkg/errors` 0.9.0,
+  would fail to ignore expected errors. Reported by Ilya Skrypitsa and
+  pgnd. GitHub #69 and #70.
 
 ## 4.1.5 (2019-11-08)
 

--- a/cmd/geoipupdate/version.go
+++ b/cmd/geoipupdate/version.go
@@ -1,5 +1,3 @@
-// +build go1.12
-
 package main
 
 import "runtime/debug"

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,10 @@ go 1.13
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gofrs/flock v0.7.1
-	github.com/kr/pretty v0.1.0 // indirect
-	github.com/pkg/errors v0.8.1
+	github.com/kr/pretty v0.2.0 // indirect
+	github.com/pkg/errors v0.9.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v2 v2.2.7 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/maxmind/geoipupdate
 
-go 1.12
+go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,17 +3,15 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gofrs/flock v0.7.1 h1:DP+LD/t0njgoPBvT5MJLeliUIVQR03hiKR6vezdwHlc=
 github.com/gofrs/flock v0.7.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
-github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.0 h1:J8lpUdobwIeCI7OiSxHqEwJUKvJwicL5+3v1oe2Yb4k=
+github.com/pkg/errors v0.9.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
-github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -24,3 +22,5 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
+gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/geoipupdate/database/local_file_writer.go
+++ b/pkg/geoipupdate/database/local_file_writer.go
@@ -95,10 +95,10 @@ func (writer *LocalFileDatabaseWriter) Write(p []byte) (int, error) {
 
 // Close closes the temporary file and releases the file lock.
 func (writer *LocalFileDatabaseWriter) Close() error {
-	if err := writer.temporaryFile.Close(); err != nil && errors.Cause(err) == os.ErrClosed {
+	if err := writer.temporaryFile.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
 		return errors.Wrap(err, "error closing temporary file")
 	}
-	if err := os.Remove(writer.temporaryFile.Name()); err != nil && errors.Cause(err) == os.ErrNotExist {
+	if err := os.Remove(writer.temporaryFile.Name()); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return errors.Wrap(err, "error removing temporary file")
 	}
 	if err := writer.lock.Unlock(); err != nil {


### PR DESCRIPTION
This updated pkg/errors to the latest release and fixes a bug in the error handling of the `Close` method on `LocalFileDatabaseWriter`, which was exposed by that upgrade.

Closes #70 and #69.