### PR TITLE
Address lints from newer golangci-lints

### DIFF
--- a/pkg/geoipupdate/database/http_reader.go
+++ b/pkg/geoipupdate/database/http_reader.go
@@ -98,7 +98,7 @@ func (reader *HTTPDatabaseReader) Get(destination Writer, editionID string) erro
 		}
 	}()
 
-	if _, err = io.Copy(destination, gzReader); err != nil {
+	if _, err = io.Copy(destination, gzReader); err != nil { //nolint:gosec
 		return errors.Wrap(err, "error writing response")
 	}
 

--- a/pkg/geoipupdate/database/http_reader_test.go
+++ b/pkg/geoipupdate/database/http_reader_test.go
@@ -203,7 +203,7 @@ func TestHTTPDatabaseReader(t *testing.T) {
 				err := ioutil.WriteFile(
 					currentDatabasePath,
 					[]byte(test.DatabaseBefore),
-					0644,
+					0600,
 				)
 				require.NoError(t, err)
 			}


### PR DESCRIPTION
The gosec nolint is for: "Potential DoS vulnerability via decompression
bomb".