### PR TITLE
Docker entrypoint: Don't print conf file to stdout

### DIFF
--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -39,8 +39,6 @@ if [ "$GEOIPUPDATE_VERBOSE" ]; then
     flags="-v"
 fi
 
-cat "$conf_file"
-
 while true; do
     echo "# STATE: Running geoipupdate"
     /usr/bin/geoipupdate -d "$database_dir" -f "$conf_file" $flags


### PR DESCRIPTION
The docker entrypoint prints out a user's account ID and license key. These values should be treated as secret. This PR stops the contents of the conf file from being exposed via stdout. Resolves #108 

Example:
```
docker run --rm -w /workspace -v `pwd`:/workspace:delegated -v `pwd`/build/usr/share/GeoIP:/usr/share/GeoIP -e GEOIPUPDATE_ACCOUNT_ID -e GEOIPUPDATE_LICENSE_KEY -e "GEOIPUPDATE_EDITION_IDS=GeoLite2-City GeoLite2-ASN" maxmindinc/geoipupdate

# STATE: Creating configuration file at /etc/GeoIP.conf
AccountID REDACTED
LicenseKey REDACTED
EditionIDs GeoLite2-City GeoLite2-ASN
...
```