### PR TITLE
Add environment variables for conf_file and database_dir

### DIFF
--- a/doc/docker.md
+++ b/doc/docker.md
@@ -33,6 +33,8 @@ The following are optional:
   default is `0`.
 * `GEOIPUPDATE_VERBOSE` - Enable verbose mode. Prints out the steps that
   `geoipupdate` takes. Set to **anything** (e.g., `1`) to enable.
+* `GEOIPUPDATE_CONF_FILE` - The path where the configuration file will be written. The default is `/etc/GeoIP.conf`.
+* `GEOIPUPDATE_DB_DIR` - The directory where geoipupdate will download the databases. The default is `/usr/share/GeoIP`.
 
 The environment variables can be placed in a file with one per line and
 passed in with the `--env-file` flag. Alternatively, you may pass them in

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -18,6 +18,15 @@ conf_file=/etc/GeoIP.conf
 database_dir=/usr/share/GeoIP
 flags=
 frequency=$((GEOIPUPDATE_FREQUENCY * 60 * 60))
+
+if ! [ -z "$GEOIPUPDATE_CONF_FILE" ]; then
+  conf_file=$GEOIPUPDATE_CONF_FILE
+fi
+
+if ! [ -z "$GEOIPUPDATE_DB_DIR" ]; then
+  database_dir=$GEOIPUPDATE_DB_DIR
+fi
+
 if [ -z "$GEOIPUPDATE_ACCOUNT_ID" ] || [ -z  "$GEOIPUPDATE_LICENSE_KEY" ] || [ -z "$GEOIPUPDATE_EDITION_IDS" ]; then
     echo "ERROR: You must set the environment variables GEOIPUPDATE_ACCOUNT_ID, GEOIPUPDATE_LICENSE_KEY, and GEOIPUPDATE_EDITION_IDS!"
     exit 1


### PR DESCRIPTION
Following #142, I also needed to run this container with another user therefore with another conf_file.
So I added a possible override on both conf_file and database_dir via environment variables.

Let me know if this is ok for you or if you need another commit to fix something.

Regards,