### PR TITLE
Use named and versioned User-Agent string like it was before Go conversion

### DIFF
--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -37,6 +37,8 @@ fi
 
 tag="v$version"
 
+perl -pi -e "s/(?<=version = \").+?(?=\")/$version/g"  pkg/geoipupdate/geoip_updater.go
+
 echo $'\nRelease notes:'
 echo "$notes"
 

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -49,6 +49,10 @@ if [ "$ok" != "y" ]; then
     exit 1
 fi
 
+git commit -m "Update for $tag" -a
+
+git push
+
 echo "Creating tag $tag"
 
 message="$version

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -37,11 +37,10 @@ fi
 
 tag="v$version"
 
-perl -pi -e "s/(?<=version = \").+?(?=\")/$version/g"  pkg/geoipupdate/geoip_updater.go
+perl -pi -e "s/(?<=Version = \").+?(?=\")/$version/g" pkg/geoipupdate/version.go
 
 echo $'\nRelease notes:'
 echo "$notes"
-
 
 read -p "Continue? (y/n) " ok
 

--- a/pkg/geoipupdate/database/http_reader.go
+++ b/pkg/geoipupdate/database/http_reader.go
@@ -149,6 +149,7 @@ func (reader *HTTPDatabaseReader) download(
 	if err != nil {
 		return "", time.Time{}, false, errors.Wrap(err, "error creating request")
 	}
+	req.Header.Add("User-Agent", "geoipupdate/"+geoipupdate.Version)
 	req.SetBasicAuth(fmt.Sprintf("%d", reader.accountID), reader.licenseKey)
 
 	response, err := reader.client.Do(req)

--- a/pkg/geoipupdate/geoip_updater.go
+++ b/pkg/geoipupdate/geoip_updater.go
@@ -15,14 +15,27 @@ import (
 	"github.com/pkg/errors"
 )
 
+var version = "4.8.0"
+
+// AddHeaderRoundTripper struct is used to add versioned User-Agent header to each request.
+type AddHeaderRoundTripper struct {
+	r http.RoundTripper
+}
+
+// RoundTrip is used to add versioned User-Agent header to each request.
+func (ahrt AddHeaderRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.Header.Add("User-Agent", "geoipupdate/"+version)
+	return ahrt.r.RoundTrip(r) // nolint: wrapcheck
+}
+
 // NewClient creates an *http.Client for use in updating.
 func NewClient(
 	config *Config,
 ) *http.Client {
-	transport := http.DefaultTransport
+	transport := AddHeaderRoundTripper{r: http.DefaultTransport}
 	if config.Proxy != nil {
 		proxy := http.ProxyURL(config.Proxy)
-		transport.(*http.Transport).Proxy = proxy
+		transport.r.(*http.Transport).Proxy = proxy
 	}
 	return &http.Client{Transport: transport}
 }

--- a/pkg/geoipupdate/geoip_updater.go
+++ b/pkg/geoipupdate/geoip_updater.go
@@ -15,27 +15,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-var version = "4.8.0"
-
-// AddHeaderRoundTripper struct is used to add versioned User-Agent header to each request.
-type AddHeaderRoundTripper struct {
-	r http.RoundTripper
-}
-
-// RoundTrip is used to add versioned User-Agent header to each request.
-func (ahrt AddHeaderRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
-	r.Header.Add("User-Agent", "geoipupdate/"+version)
-	return ahrt.r.RoundTrip(r) // nolint: wrapcheck
-}
-
 // NewClient creates an *http.Client for use in updating.
 func NewClient(
 	config *Config,
 ) *http.Client {
-	transport := AddHeaderRoundTripper{r: http.DefaultTransport}
+	transport := http.DefaultTransport
 	if config.Proxy != nil {
 		proxy := http.ProxyURL(config.Proxy)
-		transport.r.(*http.Transport).Proxy = proxy
+		transport.(*http.Transport).Proxy = proxy
 	}
 	return &http.Client{Transport: transport}
 }
@@ -63,6 +50,7 @@ func GetFilename(
 			if err != nil {
 				return errors.Wrap(err, "error creating HTTP request")
 			}
+			req.Header.Add("User-Agent", "geoipupdate/"+Version)
 
 			res, err := client.Do(req)
 			if err != nil {

--- a/pkg/geoipupdate/version.go
+++ b/pkg/geoipupdate/version.go
@@ -1,0 +1,4 @@
+package geoipupdate
+
+// Version defines current geoipupdate version.
+const Version = "4.8.0"


### PR DESCRIPTION
Before this was converted to Go, the old C code was properly defining the User-Agent header like `geoipupdate/3.1.0`

This never made it across the switch to Go and hence our User-Agents have only been `Go-http-client/2.0` (currently - and possibly `Go-http-client/1.1` previously, not sure)

This is an attempt to provide the same feature in Go so we can better track the software usage via the versioned User-Agent.