### PR TITLE
Update golangci-lint and config

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,11 +1,15 @@
 [run]
   deadline = "10m"
+
   tests = true
 
 [linters]
   disable-all = true
   enable = [
+    "asciicheck",
+    "bidichk",
     "bodyclose",
+    "contextcheck",
     "deadcode",
     "depguard",
     "durationcheck",
@@ -14,6 +18,10 @@
     "errorlint",
     "exhaustive",
     "exportloopref",
+    # We tried this liner but most places we do forced type asserts are
+    # pretty safe, e.g., an atomic.Value when everything is encapsulated
+    # in a small package.
+    # "forcetypeassert",
     "goconst",
     "gocyclo",
     "gocritic",
@@ -34,10 +42,13 @@
     "predeclared",
     "revive",
     "rowserrcheck",
+    # https://github.com/golangci/golangci-lint/issues/287
+    # "safesql",
     "sqlclosecheck",
     "staticcheck",
     "structcheck",
     "stylecheck",
+    "tenv",
     "tparallel",
     "typecheck",
     "unconvert",
@@ -49,31 +60,437 @@
     "wrapcheck",
   ]
 
+# Please note that we only use depguard for stdlib as gomodguard only
+# supports modules currently. See https://github.com/ryancurrah/gomodguard/issues/12
+[linters-settings.depguard]
+  list-type = "blacklist"
+  include-go-root = true
+  packages = [
+    # We should use github.com/pkg/errors instead
+    "errors",
+  ]
+
 [linters-settings.errcheck]
     # Ignoring Close so that we don't have to have a bunch of
     # `defer func() { _ = r.Close() }()` constructs when we
     # don't actually care about the error.
     ignore = "Close,fmt:.*"
 
+[linters-settings.errorlint]
+    errorf = true
+    asserts = true
+    comparison = true
+
 [linters-settings.exhaustive]
     default-signifies-exhaustive = true
 
+[linters-settings.gocritic]
+    enabled-checks = [
+        "appendAssign",
+        "appendCombine",
+        "argOrder",
+        "assignOp",
+        "badCall",
+        "badCond",
+        "badLock",
+        "badRegexp",
+        "badSorting",
+        "boolExprSimplify",
+        "builtinShadow",
+        "builtinShadowDecl",
+        "captLocal",
+        "caseOrder",
+        "codegenComment",
+        "commentedOutCode",
+        "commentedOutImport",
+        "commentFormatting",
+        "defaultCaseOrder",
+        "deferUnlambda",
+        "deprecatedComment",
+        "docStub",
+        "dupArg",
+        "dupBranchBody",
+        "dupCase",
+        "dupImport",
+        "dupSubExpr",
+        "elseif",
+        "emptyDecl",
+        "emptyFallthrough",
+        "emptyStringTest",
+        "equalFold",
+        "evalOrder",
+        "exitAfterDefer",
+        "exposedSyncMutex",
+        "externalErrorReassign",
+        # Given that all of our code runs on Linux and the / separate should
+        # work fine, this seems less important.
+        # "filepathJoin",
+        "flagDeref",
+        "flagName",
+        "hexLiteral",
+        "ifElseChain",
+        "importShadow",
+        "indexAlloc",
+        "initClause",
+        "mapKey",
+        "methodExprCall",
+        "nestingReduce",
+        "newDeref",
+        "nilValReturn",
+        "octalLiteral",
+        "offBy1",
+        "paramTypeCombine",
+        "preferDecodeRune",
+        "preferFilepathJoin",
+        "preferFprint",
+        "preferStringWriter",
+        "preferWriteByte",
+        "ptrToRefParam",
+        "rangeExprCopy",
+        "rangeValCopy",
+        "redundantSprint",
+        "regexpMust",
+        "regexpPattern",
+        # This might be good, but I don't think we want to encourage
+        # significant changes to regexes as we port stuff from Perl.
+        # "regexpSimplify",
+        "ruleguard",
+        "singleCaseSwitch",
+        "sliceClear",
+        "sloppyLen",
+        # This seems like it might also be good, but a lot of existing code
+        # fails.
+        # "sloppyReassign",
+        "returnAfterHttpError",
+        "sloppyTypeAssert",
+        "sortSlice",
+        "sprintfQuotedString",
+        "sqlQuery",
+        "stringXbytes",
+        "switchTrue",
+        "syncMapLoadAndDelete",
+        "timeExprSimplify",
+        "tooManyResultsChecker",
+        "truncateCmp",
+        "typeAssertChain",
+        "typeDefFirst",
+        "typeSwitchVar",
+        "typeUnparen",
+        "underef",
+        "unlabelStmt",
+        "unlambda",
+        # I am not sure we would want this linter and a lot of existing
+        # code fails.
+        # "unnamedResult",
+        "unnecessaryBlock",
+        "unnecessaryDefer",
+        "unslice",
+        "valSwap",
+        "weakCond",
+        "wrapperFunc",
+        "yodaStyleExpr",
+        # This requires explanations for "nolint" directives. This would be
+        # nice for gosec ones, but I am not sure we want it generally unless
+        # we can get the false positive rate lower.
+        # "whyNoLint"
+    ]
+
 [linters-settings.gofumpt]
     extra-rules = true
+    lang-version = "1.16"
+
+[linters-settings.gomodguard]
+  [[linters-settings.gomodguard.blocked.modules]]
+  [linters-settings.gomodguard.blocked.modules."github.com/avct/uasurfer"]
+    recommendations = ["github.com/xavivars/uasurfer"]
+    reason = "The original avct module appears abandoned."
+
+  [[linters-settings.gomodguard.blocked.modules]]
+  [linters-settings.gomodguard.blocked.modules."github.com/BurntSushi/toml"]
+    recommendations = ["github.com/pelletier/go-toml"]
+    reason = "This library panics frequently on invalid input."
+
+  [[linters-settings.gomodguard.blocked.modules]]
+  [linters-settings.gomodguard.blocked.modules."github.com/gofrs/uuid"]
+    recommendations = ["github.com/google/uuid"]
+
+  [[linters-settings.gomodguard.blocked.modules]]
+  [linters-settings.gomodguard.blocked.modules."github.com/satori/go.uuid"]
+    recommendations = ["github.com/google/uuid"]
+
+  [[linters-settings.gomodguard.blocked.modules]]
+  [linters-settings.gomodguard.blocked.modules."github.com/lib/pq"]
+    recommendations = ["github.com/jackc/pgx"]
+    reason = "This library is no longer actively maintained."
+
+  [[linters-settings.gomodguard.blocked.modules]]
+  [linters-settings.gomodguard.blocked.modules."github.com/neilotoole/errgroup"]
+    recommendations = ["golang.org/x/sync/errgroup"]
+    reason = "This library can lead to subtle deadlocks in certain use cases."
+
+  [[linters-settings.gomodguard.blocked.modules]]
+  [linters-settings.gomodguard.blocked.modules."github.com/pariz/gountries"]
+    reason = "This library's data is not actively maintained. Use GeoInfo data."
+
+  [[linters-settings.gomodguard.blocked.modules]]
+  [linters-settings.gomodguard.blocked.modules."github.com/RackSec/srslog"]
+    recommendations = ["github.com/RackSec/srslog"]
+    reason = "This library's data is not actively maintained."
+
+  [[linters-settings.gomodguard.blocked.modules]]
+  [linters-settings.gomodguard.blocked.modules."github.com/ua-parser/uap-go/uaparser"]
+    recommendations = ["github.com/xavivars/uasurfer"]
+    reason = "The performance of this library is absolutely abysmal."
+
+  [[linters-settings.gomodguard.blocked.modules]]
+  [linters-settings.gomodguard.blocked.modules."github.com/ugorji/go/codec"]
+    recommendations = ["encoding/json", "github.com/mailru/easyjson"]
+    reason = "This library is poorly maintained. We should default to using encoding/json and use easyjson where performance really matters."
+
+  [[linters-settings.gomodguard.blocked.versions]]
+  [linters-settings.gomodguard.blocked.versions."github.com/jackc/pgx"]
+    version = "< 4.0.0"
+    reason = "Use github.com/jackc/pgx/v4"
+
+[linters-settings.govet]
+    "enable-all" = true
 
 [linters-settings.lll]
     line-length = 120
     tab-width = 4
 
+[linters-settings.nolintlint]
+    allow-leading-space = false
+    allow-unused = false
+    allow-no-explanation = ["lll"]
+    require-explanation = true
+    require-specific = true
+
+[linters-settings.revive]
+    ignore-generated-header = true
+    severity = "warning"
+
+    # This might be nice but it is so common that it is hard
+    # to enable.
+    # [[linters-settings.revive.rules]]
+    # name = "add-constant"
+
+    # [[linters-settings.revive.rules]]
+    # name = "argument-limit"
+
+    [[linters-settings.revive.rules]]
+    name = "atomic"
+
+    [[linters-settings.revive.rules]]
+    name = "bare-return"
+
+    [[linters-settings.revive.rules]]
+    name = "blank-imports"
+
+    [[linters-settings.revive.rules]]
+    name = "bool-literal-in-expr"
+
+    [[linters-settings.revive.rules]]
+    name = "call-to-gc"
+
+    # [[linters-settings.revive.rules]]
+    # name = "cognitive-complexity"
+
+    # Probably a good rule, but we have a lot of names that
+    # only have case differences.
+    # [[linters-settings.revive.rules]]
+    # name = "confusing-naming"
+
+    [[linters-settings.revive.rules]]
+    name = "confusing-results"
+
+    [[linters-settings.revive.rules]]
+    name = "constant-logical-expr"
+
+    [[linters-settings.revive.rules]]
+    name = "context-as-argument"
+
+    [[linters-settings.revive.rules]]
+    name = "context-keys-type"
+
+    # [[linters-settings.revive.rules]]
+    # name = "cyclomatic"
+
+    [[linters-settings.revive.rules]]
+    name = "deep-exit"
+
+    [[linters-settings.revive.rules]]
+    name = "defer"
+
+    [[linters-settings.revive.rules]]
+    name = "dot-imports"
+
+    [[linters-settings.revive.rules]]
+    name = "duplicated-imports"
+
+    [[linters-settings.revive.rules]]
+    name = "early-return"
+
+    [[linters-settings.revive.rules]]
+    name = "empty-block"
+
+    [[linters-settings.revive.rules]]
+    name = "empty-lines"
+
+    [[linters-settings.revive.rules]]
+    name = "errorf"
+
+    [[linters-settings.revive.rules]]
+    name = "error-naming"
+
+    [[linters-settings.revive.rules]]
+    name = "error-return"
+
+    [[linters-settings.revive.rules]]
+    name = "error-strings"
+
+    [[linters-settings.revive.rules]]
+    name = "exported"
+
+    # [[linters-settings.revive.rules]]
+    # name = "file-header"
+
+    # We have a lot of flag parameters. This linter probably makes
+    # a good point, but we would need some cleanup or a lot of nolints.
+    # [[linters-settings.revive.rules]]
+    # name = "flag-parameter"
+
+    # [[linters-settings.revive.rules]]
+    # name = "function-result-limit"
+
+    [[linters-settings.revive.rules]]
+    name = "get-return"
+
+    [[linters-settings.revive.rules]]
+    name = "identical-branches"
+
+    [[linters-settings.revive.rules]]
+    name = "if-return"
+
+    [[linters-settings.revive.rules]]
+    name = "imports-blacklist"
+
+    [[linters-settings.revive.rules]]
+    name = "import-shadowing"
+
+    [[linters-settings.revive.rules]]
+    name = "increment-decrement"
+
+    [[linters-settings.revive.rules]]
+    name = "indent-error-flow"
+
+    # [[linters-settings.revive.rules]]
+    # name = "line-length-limit"
+
+    # [[linters-settings.revive.rules]]
+    # name = "max-public-structs"
+
+    [[linters-settings.revive.rules]]
+    name = "modifies-parameter"
+
+    [[linters-settings.revive.rules]]
+    name = "modifies-value-receiver"
+
+    # We frequently use nested structs, particularly in tests.
+    # [[linters-settings.revive.rules]]
+    # name = "nested-structs"
+
+
+    [[linters-settings.revive.rules]]
+    name = "package-comments"
+
+    [[linters-settings.revive.rules]]
+    name = "range"
+
+    [[linters-settings.revive.rules]]
+    name = "range-val-address"
+
+    [[linters-settings.revive.rules]]
+    name = "range-val-in-closure"
+
+    [[linters-settings.revive.rules]]
+    name = "receiver-naming"
+
+    [[linters-settings.revive.rules]]
+    name = "redefines-builtin-id"
+
+    [[linters-settings.revive.rules]]
+    name = "string-of-int"
+
+    [[linters-settings.revive.rules]]
+    name = "struct-tag"
+
+    [[linters-settings.revive.rules]]
+    name = "superfluous-else"
+
+    [[linters-settings.revive.rules]]
+    name = "time-naming"
+
+    [[linters-settings.revive.rules]]
+    name = "unconditional-recursion"
+
+    [[linters-settings.revive.rules]]
+    name = "unexported-naming"
+
+    [[linters-settings.revive.rules]]
+    name = "unexported-return"
+
+    # This is covered elsewhere and we want to ignore some
+    # functions such as fmt.Fprintf.
+    # [[linters-settings.revive.rules]]
+    # name = "unhandled-error"
+
+    [[linters-settings.revive.rules]]
+    name = "unnecessary-stmt"
+
+    [[linters-settings.revive.rules]]
+    name = "unreachable-code"
+
+    [[linters-settings.revive.rules]]
+    name = "unused-parameter"
+
+    # We generally have unused receivers in tests for meeting the
+    # requirements of an interface.
+    # [[linters-settings.revive.rules]]
+    # name = "unused-receiver"
+
+    [[linters-settings.revive.rules]]
+    name = "useless-break"
+
+    [[linters-settings.revive.rules]]
+    name = "var-declaration"
+
+    [[linters-settings.revive.rules]]
+    name = "var-naming"
+
+    [[linters-settings.revive.rules]]
+    name = "waitgroup-by-value"
+
+[linters-settings.unparam]
+    check-exported = true
+
+[linters-settings.wrapcheck]
+    "ignoreSigs" = [
+        ".Errorf(",
+        "errgroup.NewMultiError(",
+        "errors.New(",
+        ".Wait(",
+        ".WithMessage(",
+        ".WithMessagef(",
+        ".WithStack(",
+        ".Wrap(",
+        ".Wrapf(",
+        "v4.Retry(",
+        "v4.RetryNotify(",
+    ]
+
 [issues]
 exclude-use-default = false
-
-  [[issues.exclude-rules]]
-  linters = [
-    "gosec"
-  ]
-  # G306 - "Expect WriteFile permissions to be 0600 or less".
-  text = "G306"
 
   # This goes off for MD5 usage, which we use heavily
   [[issues.exclude-rules]]
@@ -82,6 +499,86 @@ exclude-use-default = false
 
   [[issues.exclude-rules]]
   linters = [
+    "gocritic"
+  ]
+  # For some reason the imports stuff in ruleguard doesn't work in golangci-lint.
+  # Perhaps it has an outdated version or something
+  path = "_test.go"
+  text = "ruleguard: Prefer the alternative Context method instead"
+
+  [[issues.exclude-rules]]
+  linters = [
+    "gocritic"
+  ]
+  ## The nolintlint linter behaves oddly with ruleguard rules
+  source = "// *no-ruleguard"
+
+
+  [[issues.exclude-rules]]
+  linters = [
+    "gosec"
+  ]
+  # G306 - "Expect WriteFile permissions to be 0600 or less".
+  text = "G306"
+
+  [[issues.exclude-rules]]
+  linters = [
+    "govet"
+  ]
+  # we want to enable almost all govet rules. It is easier to just filter out
+  # the ones we don't want:
+  #
+  # * fieldalignment - way too noisy. Although it is very useful in particular
+  #   cases where we are trying to use as little memory as possible, having
+  #   it go off on every struct isn't helpful.
+  # * shadow - although often useful, it complains about _many_ err
+  #   shadowing assignments and some others where shadowing is clear.
+  text = "^(fieldalignment|shadow)"
+
+  [[issues.exclude-rules]]
+  linters = [
+    "govet"
+  ]
+  text = "shadow: declaration of \"err\" shadows declaration"
+
+  [[issues.exclude-rules]]
+  linters = [
+    "contextcheck",
+    "nilerr",
+    "wrapcheck",
+  ]
+  path = "_test.go"
+
+  [[issues.exclude-rules]]
+  linters = [
+    "stylecheck",
+  ]
+  # ST1016 - methods on the same type should have the same receiver name.
+  #    easyjson doesn't interact well with this.
+  text = "ST1016"
+
+  [[issues.exclude-rules]]
+  linters = [
+    "staticcheck",
+  ]
+  # SA5008: unknown JSON option "intern" - easyjson specific option.
+  text = 'SA5008: unknown JSON option "intern"'
+
+  [[issues.exclude-rules]]
+  linters = [
     "wrapcheck"
   ]
   text = "github.com/maxmind/geoipupdate"
+
+  [[issues.exclude-rules]]
+  linters = [
+    "wrapcheck",
+  ]
+  path = "_easyjson.go"
+
+  [[issues.exclude-rules]]
+  linters = [
+    "gocritic",
+  ]
+  source = "Chmod|WriteFile"
+  text = "octalLiteral"

--- a/cmd/geoipupdate/args.go
+++ b/cmd/geoipupdate/args.go
@@ -40,6 +40,7 @@ func getArgs() *Args {
 	}
 	if *displayVersion {
 		log.Printf("geoipupdate %s", version)
+		//nolint: revive // deep exit from main package
 		os.Exit(0)
 	}
 
@@ -59,5 +60,6 @@ func getArgs() *Args {
 func printUsage() {
 	log.Printf("Usage: %s <arguments>\n", os.Args[0])
 	flag.PrintDefaults()
+	//nolint: revive // deep exit from main package
 	os.Exit(1)
 }

--- a/cmd/geoipupdate/end_to_end_test.go
+++ b/cmd/geoipupdate/end_to_end_test.go
@@ -94,7 +94,7 @@ func TestMultipleDatabaseDownload(t *testing.T) {
 
 	for _, editionID := range config.EditionIDs {
 		path := filepath.Join(config.DatabaseDirectory, editionID+".mmdb")
-		buf, err := ioutil.ReadFile(path) //nolint:gosec
+		buf, err := ioutil.ReadFile(filepath.Clean(path))
 		require.NoError(t, err, "read file")
 		assert.Equal(
 			t,

--- a/pkg/geoipupdate/config.go
+++ b/pkg/geoipupdate/config.go
@@ -29,7 +29,7 @@ type Config struct {
 }
 
 // NewConfig parses the configuration file.
-func NewConfig( // nolint: gocyclo
+func NewConfig( //nolint: gocyclo // long but breaking it up may be worse
 	file,
 	defaultDatabaseDirectory,
 	databaseDirectory string,

--- a/pkg/geoipupdate/config.go
+++ b/pkg/geoipupdate/config.go
@@ -39,6 +39,7 @@ func NewConfig( // nolint: gocyclo
 	if err != nil {
 		return nil, errors.Wrap(err, "error opening file")
 	}
+	//nolint: gosec // see https://github.com/securego/gosec/issues/714
 	defer func() {
 		if err := fh.Close(); err != nil {
 			log.Fatalf("Error closing config file: %+v", errors.Wrap(err, "closing file"))

--- a/pkg/geoipupdate/config.go
+++ b/pkg/geoipupdate/config.go
@@ -2,7 +2,6 @@ package geoipupdate
 
 import (
 	"bufio"
-	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -39,12 +38,9 @@ func NewConfig( //nolint: gocyclo // long but breaking it up may be worse
 	if err != nil {
 		return nil, errors.Wrap(err, "error opening file")
 	}
-	//nolint: gosec // see https://github.com/securego/gosec/issues/714
-	defer func() {
-		if err := fh.Close(); err != nil {
-			log.Fatalf("Error closing config file: %+v", errors.Wrap(err, "closing file"))
-		}
-	}()
+
+	//nolint: gosec // We don't particularly care if the close fails
+	defer fh.Close()
 
 	config := &Config{}
 	scanner := bufio.NewScanner(fh)

--- a/pkg/geoipupdate/config_test.go
+++ b/pkg/geoipupdate/config_test.go
@@ -328,7 +328,7 @@ SkipPeerVerification 1
 		{
 			Description: "CR line ending does not work",
 			Input:       "AccountID 0\rLicenseKey 123\rEditionIDs GeoIP2-City\r",
-			// nolint: lll
+			//nolint: lll
 			Err: `invalid account ID format: strconv.Atoi: parsing "0 LicenseKey 123 EditionIDs GeoIP2-City": invalid syntax`,
 		},
 		{

--- a/pkg/geoipupdate/database/http_reader.go
+++ b/pkg/geoipupdate/database/http_reader.go
@@ -157,11 +157,8 @@ func (reader *HTTPDatabaseReader) download(
 	if err != nil {
 		return "", time.Time{}, false, errors.Wrap(err, "error performing HTTP request")
 	}
-	defer func() {
-		if err := response.Body.Close(); err != nil {
-			log.Fatalf("Error closing response body: %+v", errors.Wrap(err, "closing body"))
-		}
-	}()
+
+	defer response.Body.Close()
 
 	if response.StatusCode == http.StatusNotModified {
 		if reader.verbose {

--- a/pkg/geoipupdate/database/http_reader.go
+++ b/pkg/geoipupdate/database/http_reader.go
@@ -145,8 +145,8 @@ func (reader *HTTPDatabaseReader) download(
 	}
 
 	// Perform the download.
-
-	req, err := http.NewRequest(http.MethodGet, updateURL, nil) // nolint: noctx
+	//nolint: noctx // using the context would require an API change
+	req, err := http.NewRequest(http.MethodGet, updateURL, nil)
 	if err != nil {
 		return "", time.Time{}, false, errors.Wrap(err, "error creating request")
 	}
@@ -195,7 +195,8 @@ func (reader *HTTPDatabaseReader) download(
 		}
 	}()
 
-	if _, err := io.Copy(tempFile, gzReader); err != nil { //nolint:gosec
+	//nolint:gosec // A decompression bomb is unlikely here
+	if _, err := io.Copy(tempFile, gzReader); err != nil {
 		return "", time.Time{}, false, errors.Wrap(err, "error writing response")
 	}
 

--- a/pkg/geoipupdate/database/http_reader.go
+++ b/pkg/geoipupdate/database/http_reader.go
@@ -70,6 +70,7 @@ func (reader *HTTPDatabaseReader) Get(destination Writer, editionID string) erro
 	if err != nil {
 		return errors.Wrap(err, "error opening temporary file")
 	}
+	//nolint: gosec // see https://github.com/securego/gosec/issues/714
 	defer func() {
 		if err := tempFile.Close(); err != nil {
 			log.Printf("error closing temporary file: %s", err)

--- a/pkg/geoipupdate/database/http_reader_test.go
+++ b/pkg/geoipupdate/database/http_reader_test.go
@@ -97,7 +97,7 @@ func TestHTTPDatabaseReader(t *testing.T) {
 			DownloadHeaders: map[string]string{
 				"X-Database-MD5": "5d41402abc4b2a76b9719d911017c592", // "hello"
 			},
-			// nolint: lll
+			//nolint: lll
 			Err: `md5 of new database \(985ecf3d7959b146208b3dc0189b21a5\) does not match expected md5 \(5d41402abc4b2a76b9719d911017c592\)`,
 		},
 		{
@@ -192,7 +192,8 @@ func TestHTTPDatabaseReader(t *testing.T) {
 			}
 
 			if test.CreateDirectory {
-				err := os.Mkdir(config.DatabaseDirectory, 0o755) //nolint:gosec
+				//nolint:gosec // seems ok in test
+				err := os.Mkdir(config.DatabaseDirectory, 0o755)
 				require.NoError(t, err)
 			}
 

--- a/pkg/geoipupdate/database/local_file_writer.go
+++ b/pkg/geoipupdate/database/local_file_writer.go
@@ -154,16 +154,14 @@ func (writer *LocalFileDatabaseWriter) Commit() error {
 	if err != nil {
 		return errors.Wrap(err, "error opening database directory")
 	}
-	//nolint: gosec // see https://github.com/securego/gosec/issues/714
-	defer func() {
-		if err := dh.Close(); err != nil {
-			log.Fatalf("Error closing directory: %+v", errors.Wrap(err, "closing directory"))
-		}
-	}()
 
 	// We ignore Sync errors as they primarily happen on file systems that do
 	// not support sync.
 	_ = dh.Sync()
+
+	if err := dh.Close(); err != nil {
+		return errors.Wrap(err, "closing directory")
+	}
 	return nil
 }
 

--- a/pkg/geoipupdate/database/local_file_writer.go
+++ b/pkg/geoipupdate/database/local_file_writer.go
@@ -71,6 +71,7 @@ func (writer *LocalFileDatabaseWriter) createOldMD5Hash() error {
 		return errors.Wrap(err, "error opening database")
 	}
 
+	//nolint: gosec // see https://github.com/securego/gosec/issues/714
 	defer func() {
 		err := currentDatabaseFile.Close()
 		if err != nil {
@@ -152,6 +153,7 @@ func (writer *LocalFileDatabaseWriter) Commit() error {
 	if err != nil {
 		return errors.Wrap(err, "error opening database directory")
 	}
+	//nolint: gosec // see https://github.com/securego/gosec/issues/714
 	defer func() {
 		if err := dh.Close(); err != nil {
 			log.Fatalf("Error closing directory: %+v", errors.Wrap(err, "closing directory"))

--- a/pkg/geoipupdate/database/local_file_writer.go
+++ b/pkg/geoipupdate/database/local_file_writer.go
@@ -47,7 +47,8 @@ func NewLocalFileDatabaseWriter(filePath, lockFilePath string, verbose bool) (*L
 	}
 
 	temporaryFilename := fmt.Sprintf("%s.temporary", dbWriter.filePath)
-	dbWriter.temporaryFile, err = os.OpenFile( //nolint:gosec
+	//nolint:gosec // We want the permission to be world readable
+	dbWriter.temporaryFile, err = os.OpenFile(
 		temporaryFilename,
 		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
 		0o644,

--- a/pkg/geoipupdate/geoip_updater.go
+++ b/pkg/geoipupdate/geoip_updater.go
@@ -46,7 +46,8 @@ func GetFilename(
 				log.Printf("Performing get filename request to %s", maxMindURL)
 			}
 
-			req, err := http.NewRequest(http.MethodGet, maxMindURL, nil) // nolint: noctx
+			//nolint: noctx // as it would require a breaking API change
+			req, err := http.NewRequest(http.MethodGet, maxMindURL, nil)
 			if err != nil {
 				return errors.Wrap(err, "error creating HTTP request")
 			}

--- a/pkg/geoipupdate/geoip_updater.go
+++ b/pkg/geoipupdate/geoip_updater.go
@@ -57,15 +57,15 @@ func GetFilename(
 			if err != nil {
 				return errors.Wrap(err, "error performing HTTP request")
 			}
-			defer func() {
-				if err := res.Body.Close(); err != nil {
-					log.Fatalf("error closing response body: %+v", errors.Wrap(err, "closing body"))
-				}
-			}()
 
 			buf, err = ioutil.ReadAll(io.LimitReader(res.Body, 256))
 			if err != nil {
+				_ = res.Body.Close()
 				return errors.Wrap(err, "error reading response body")
+			}
+
+			if err := res.Body.Close(); err != nil {
+				return errors.Wrap(err, "closing body")
 			}
 
 			if res.StatusCode != http.StatusOK {


### PR DESCRIPTION
- Ignore broken G307 lints
- Modernize golangci-config
- Give nolint reasons and format them
- Fix deep exits or ignore
- Use filepath.Clean instance of nolint
