### PR TITLE
Remove unnecessary filename query

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -140,7 +140,7 @@ nfpms:
     vendor: 'MaxMind, Inc.'
     homepage: https://www.maxmind.com/
     maintainer: 'MaxMind, Inc. <support@maxmind.com>'
-    description: Program to perform automatic updates of GeoIP2 binary databases.
+    description: Program to perform automatic updates of GeoIP2 and GeoLite2 binary databases.
     license: Apache 2.0 or MIT
     formats:
       - deb

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -140,7 +140,7 @@ nfpms:
     vendor: 'MaxMind, Inc.'
     homepage: https://www.maxmind.com/
     maintainer: 'MaxMind, Inc. <support@maxmind.com>'
-    description: Program to perform automatic updates of GeoIP2 and GeoIP Legacy binary databases.
+    description: Program to perform automatic updates of GeoIP2 binary databases.
     license: Apache 2.0 or MIT
     formats:
       - deb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * HTTPS proxies are now supported. Pull request by Jamie Thompson. GitHub
   #172.
+* An HTTP request to get the filename for the edition ID has been removed.
+  This was previously required as the GeoIP Legacy edition IDs bore little
+  relation to the name of the database on disk.
 
 ## 4.9.0 (2022-02-15)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GeoIP Update
 
-The GeoIP Update program performs automatic updates of GeoIP2 binary
-databases. CSV databases are _not_ supported.
+The GeoIP Update program performs automatic updates of GeoIP2 and
+GeoLite2 binary databases. CSV databases are _not_ supported.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ time using flags:
 
 # Bug Reports
 
-Please report bugs by filing an issue with our GitHub issue tracker at
-https://github.com/maxmind/geoipupdate/issues
+Please report bugs by filing an issue with [our GitHub issue
+tracker](https://github.com/maxmind/geoipupdate/issues).
 
 # Copyright and License
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GeoIP Update
 
-The GeoIP Update program performs automatic updates of GeoIP2 and GeoIP Legacy
-binary databases. CSV databases are _not_ supported.
+The GeoIP Update program performs automatic updates of GeoIP2 binary
+databases. CSV databases are _not_ supported.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Please see our [Docker documentation](doc/docker.md).
 
 ### Installation from source or Git
 
-You need the Go compiler (1.8+). You can get it at the [Go
+You need the Go compiler (1.13+). You can get it at the [Go
 website](https://golang.org).
 
 The easiest way is via `go get`:

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ We provide releases for Linux, macOS (darwin), and Windows. Please see the
 [Releases](https://github.com/maxmind/geoipupdate/releases) tab for the
 latest release.
 
-After you install geoipupdate, please refer to our
+After you install GeoIP Update, please refer to our
 [documentation](https://dev.maxmind.com/geoip/updating-databases?lang=en) for information
 about configuration.
 
-If you're upgrading from geoipupdate 3.x, please see our [upgrade
+If you're upgrading from GeoIP Update 3.x, please see our [upgrade
 guide](https://dev.maxmind.com/geoip/upgrading-geoip-update?lang=en).
 
 ### Installing on Linux via the tarball

--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@
 The GeoIP Update program performs automatic updates of GeoIP2 and GeoIP Legacy
 binary databases. CSV databases are _not_ supported.
 
-This is the new version of GeoIP Update. If for some reason you need the
-legacy C version, you can find it
-[here](https://github.com/maxmind/geoipupdate-legacy).
-
 ## Installation
 
 We provide releases for Linux, macOS (darwin), and Windows. Please see the

--- a/cmd/geoipupdate/end_to_end_test.go
+++ b/cmd/geoipupdate/end_to_end_test.go
@@ -54,12 +54,6 @@ func TestMultipleDatabaseDownload(t *testing.T) {
 					return
 				}
 
-				if r.URL.Path == "/app/update_getfilename" {
-					_, err := rw.Write([]byte(r.Form.Get("product_id") + ".mmdb"))
-					require.NoError(t, err)
-					return
-				}
-
 				rw.WriteHeader(http.StatusBadRequest)
 			},
 		),

--- a/doc/GeoIP.conf.md
+++ b/doc/GeoIP.conf.md
@@ -5,7 +5,7 @@ GeoIP.conf - Configuration file for geoipupdate
 # SYNOPSIS
 
 This file allows you to configure your `geoipupdate` program to
-download GeoIP2, GeoLite2, and GeoIP Legacy databases.
+download GeoIP2 and GeoLite2.
 
 # DESCRIPTION
 
@@ -27,8 +27,8 @@ sensitive.
 
 :   List of space-separated database edition IDs. Edition IDs may consist
     of letters, digits, and dashes.  For example, `GeoIP2-City 106` would
-    download the GeoIP2 City database (`GeoIP2-City`) and the GeoIP Legacy
-    Country database (`106`). Note: this was formerly called `ProductIds`.
+    download the GeoIP2 City database (`GeoIP2-City`). Note: this was
+    formerly called `ProductIds`.
 
 ## Optional settings:
 

--- a/doc/GeoIP.conf.md
+++ b/doc/GeoIP.conf.md
@@ -5,7 +5,7 @@ GeoIP.conf - Configuration file for geoipupdate
 # SYNOPSIS
 
 This file allows you to configure your `geoipupdate` program to
-download GeoIP2 and GeoLite2.
+download GeoIP2 and GeoLite2 databases.
 
 # DESCRIPTION
 
@@ -26,7 +26,7 @@ sensitive.
 `EditionIDs`
 
 :   List of space-separated database edition IDs. Edition IDs may consist
-    of letters, digits, and dashes.  For example, `GeoIP2-City 106` would
+    of letters, digits, and dashes.  For example, `GeoIP2-City` would
     download the GeoIP2 City database (`GeoIP2-City`). Note: this was
     formerly called `ProductIds`.
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -14,8 +14,7 @@ variables are required:
 * `GEOIPUPDATE_LICENSE_KEY` - Your case-sensitive MaxMind license key.
 * `GEOIPUPDATE_EDITION_IDS` - List of space-separated database edition IDs.
   Edition IDs may consist of letters, digits, and dashes. For example,
-  `GeoIP2-City 106` would download the GeoIP2 City database
-  (`GeoIP2-City`) and the GeoIP Legacy Country database (`106`).
+  `GeoIP2-City` would download the GeoIP2 City database (`GeoIP2-City`).
 
 The following are optional:
 

--- a/doc/geoipupdate.md
+++ b/doc/geoipupdate.md
@@ -1,6 +1,6 @@
 # NAME
 
-geoipupdate - GeoIP2, GeoLite2, and GeoIP Legacy Update Program
+geoipupdate - GeoIP2 and GeoLite2 Update Program
 
 # SYNOPSIS
 
@@ -8,17 +8,16 @@ geoipupdate - GeoIP2, GeoLite2, and GeoIP Legacy Update Program
 
 # DESCRIPTION
 
-`geoipupdate` automatically updates GeoIP2, GeoLite2, and GeoIP Legacy
-databases. The program connects to the MaxMind GeoIP Update server to
-check for new databases. If a new database is available, the program will
-download and install it.
+`geoipupdate` automatically updates GeoIP2 databases. The program connects
+to the MaxMind GeoIP Update server to check for new databases. If a new
+database is available, the program will download and install it.
 
 If you are using a firewall, you must have the DNS and HTTPS ports
 open.
 
 # OPTIONS
 
-`-d`, `--database-directory`
+`-d`, database-directory`
 
 :   Install databases to a custom directory.  This is optional. If provided, it
     overrides any `DatabaseDirectory` set in the configuration file.
@@ -84,7 +83,7 @@ the MIT License, at your option.
 # MORE INFORMATION
 
 Visit [our website](https://www.maxmind.com/en/geoip2-services-and-databases)
-to learn more about the GeoIP2 and GeoIP Legacy databases or to sign up
+to learn more about the GeoIP2 databases or to sign up
 for a subscription.
 
 # SEE ALSO

--- a/doc/geoipupdate.md
+++ b/doc/geoipupdate.md
@@ -8,16 +8,17 @@ geoipupdate - GeoIP2 and GeoLite2 Update Program
 
 # DESCRIPTION
 
-`geoipupdate` automatically updates GeoIP2 databases. The program connects
-to the MaxMind GeoIP Update server to check for new databases. If a new
-database is available, the program will download and install it.
+`geoipupdate` automatically updates GeoIP2 and GeoLite2 databases. The
+program connects to the MaxMind GeoIP Update server to check for new
+databases. If a new database is available, the program will download and
+install it.
 
 If you are using a firewall, you must have the DNS and HTTPS ports
 open.
 
 # OPTIONS
 
-`-d`, database-directory`
+`-d`, `--database-directory`
 
 :   Install databases to a custom directory.  This is optional. If provided, it
     overrides any `DatabaseDirectory` set in the configuration file.
@@ -83,8 +84,7 @@ the MIT License, at your option.
 # MORE INFORMATION
 
 Visit [our website](https://www.maxmind.com/en/geoip2-services-and-databases)
-to learn more about the GeoIP2 databases or to sign up
-for a subscription.
+to learn more about the GeoIP2 databases or to sign up for a subscription.
 
 # SEE ALSO
 

--- a/pkg/geoipupdate/geoip_updater.go
+++ b/pkg/geoipupdate/geoip_updater.go
@@ -3,16 +3,7 @@
 package geoipupdate
 
 import (
-	"bytes"
-	"fmt"
-	"io"
-	"io/ioutil"
-	"log"
 	"net/http"
-	"net/url"
-
-	"github.com/maxmind/geoipupdate/v4/pkg/geoipupdate/internal"
-	"github.com/pkg/errors"
 )
 
 // NewClient creates an *http.Client for use in updating.
@@ -27,71 +18,11 @@ func NewClient(
 	return &http.Client{Transport: transport}
 }
 
-// GetFilename looks up the filename for the given edition ID.
+// GetFilename returns the filename for the given edition ID.
 func GetFilename(
-	config *Config,
+	_ *Config,
 	editionID string,
-	client *http.Client,
-) (string, error) {
-	maxMindURL := fmt.Sprintf(
-		"%s/app/update_getfilename?product_id=%s",
-		config.URL,
-		url.QueryEscape(editionID),
-	)
-
-	var buf []byte
-	err := internal.RetryWithBackoff(
-		func() error {
-			if config.Verbose {
-				log.Printf("Performing get filename request to %s", maxMindURL)
-			}
-
-			//nolint: noctx // as it would require a breaking API change
-			req, err := http.NewRequest(http.MethodGet, maxMindURL, nil)
-			if err != nil {
-				return errors.Wrap(err, "error creating HTTP request")
-			}
-			req.Header.Add("User-Agent", "geoipupdate/"+Version)
-
-			res, err := client.Do(req)
-			if err != nil {
-				return errors.Wrap(err, "error performing HTTP request")
-			}
-
-			buf, err = ioutil.ReadAll(io.LimitReader(res.Body, 256))
-			if err != nil {
-				_ = res.Body.Close()
-				return errors.Wrap(err, "error reading response body")
-			}
-
-			if err := res.Body.Close(); err != nil {
-				return errors.Wrap(err, "closing body")
-			}
-
-			if res.StatusCode != http.StatusOK {
-				err := internal.HTTPError{
-					Body:       string(buf),
-					StatusCode: res.StatusCode,
-				}
-				return errors.Wrap(err, "unexpected HTTP status code")
-			}
-
-			if len(buf) == 0 {
-				return errors.New("response body is empty")
-			}
-
-			if bytes.Count(buf, []byte("\n")) > 0 ||
-				bytes.Count(buf, []byte("\x00")) > 0 {
-				return errors.New("invalid characters in filename")
-			}
-
-			return nil
-		},
-		config.RetryFor,
-	)
-	if err != nil {
-		return "", err
-	}
-
-	return string(buf), nil
+	_ *http.Client,
+) (string, error) { //nolint:unparam // the error return value was kept for API compatibility
+	return editionID + ".mmdb", nil
 }

--- a/pkg/geoipupdate/geoip_updater_test.go
+++ b/pkg/geoipupdate/geoip_updater_test.go
@@ -1,92 +1,16 @@
 package geoipupdate
 
 import (
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGetFileName(t *testing.T) {
-	tests := []struct {
-		Description    string
-		FilenameStatus int
-		FilenameBody   string
-		ExpectedError  string
-		ExpectedOutput string
-	}{
-		{
-			Description:    "Simple Success",
-			FilenameStatus: http.StatusOK,
-			FilenameBody:   "aSimpleFileName",
-			ExpectedOutput: "aSimpleFileName",
-		},
-		{
-			Description:    "Get filename fails",
-			FilenameStatus: http.StatusBadRequest,
-			ExpectedError:  "unexpected HTTP status code: received HTTP status code: 400: ",
-		},
-		{
-			Description:    "Get filename is missing body",
-			FilenameStatus: http.StatusOK,
-			ExpectedError:  "response body is empty",
-		},
-		{
-			Description:    "Get filename has newlines",
-			FilenameStatus: http.StatusOK,
-			FilenameBody:   "bad\nfilename",
-			ExpectedError:  "invalid characters in filename",
-		},
-	}
-
-	tempDir, err := ioutil.TempDir("", "gutest-")
-	require.NoError(t, err)
-	defer func() {
-		err = os.RemoveAll(tempDir)
-		require.NoError(t, err)
-	}()
-
-	for _, test := range tests {
-		t.Run(test.Description, func(t *testing.T) {
-			server := httptest.NewServer(
-				http.HandlerFunc(
-					func(rw http.ResponseWriter, r *http.Request) {
-						if r.URL.Path == "/app/update_getfilename" {
-							rw.WriteHeader(test.FilenameStatus)
-							_, err := rw.Write([]byte(test.FilenameBody))
-							require.NoError(t, err)
-							return
-						}
-						if r.URL.Path == "/go-here" {
-							rw.WriteHeader(http.StatusNotModified)
-							return
-						}
-						rw.WriteHeader(http.StatusBadRequest)
-					},
-				),
-			)
-
-			config := &Config{
-				AccountID:         123,
-				DatabaseDirectory: tempDir,
-				EditionIDs:        []string{"GeoIP2-City"},
-				LicenseKey:        "testing",
-				LockFile:          filepath.Join(tempDir, ".geoipupdate.lock"),
-				URL:               server.URL,
-			}
-			client := NewClient(config)
-			actualOutput, actualError := GetFilename(config, config.EditionIDs[0], client)
-
-			assert.Equal(t, test.ExpectedOutput, actualOutput, test.Description)
-			if test.ExpectedError != "" {
-				require.Error(t, actualError, test.Description)
-				assert.Equal(t, test.ExpectedError, actualError.Error(), test.Description)
-			}
-		})
-	}
+	filename, _ := GetFilename(nil, "GeoIP2-City", nil)
+	assert.Equal(
+		t,
+		"GeoIP2-City.mmdb",
+		filename,
+	)
 }


### PR DESCRIPTION
- Stop making requests to /app/update_getfilename
- Remove reference to legacy geoipupdate
- Be consistent about how we refer to the program
- Update required Go version in docs
- Use Markdown link for issue tracker
- Remove references to GeoIP Legacy
