### PR TITLE
Add body to err message

### DIFF
--- a/pkg/geoipupdate/database/http_reader.go
+++ b/pkg/geoipupdate/database/http_reader.go
@@ -176,6 +176,7 @@ func (reader *HTTPDatabaseReader) download(
 			return "", time.Time{}, false, fmt.Errorf("unexpected HTTP status code: %w", err)
 		}
 		err = internal.HTTPError{
+			Body:       string(buf),
 			StatusCode: response.StatusCode,
 		}
 		return "", time.Time{}, false, fmt.Errorf("unexpected HTTP status code: %w", err)

--- a/pkg/geoipupdate/database/http_reader.go
+++ b/pkg/geoipupdate/database/http_reader.go
@@ -167,19 +167,12 @@ func (reader *HTTPDatabaseReader) download(
 	}
 
 	if response.StatusCode != http.StatusOK {
-		buf, err := ioutil.ReadAll(io.LimitReader(response.Body, 256))
-		if err == nil {
-			err := internal.HTTPError{
-				Body:       string(buf),
-				StatusCode: response.StatusCode,
-			}
-			return "", time.Time{}, false, fmt.Errorf("unexpected HTTP status code: %w", err)
-		}
-		err = internal.HTTPError{
+		buf, _ := ioutil.ReadAll(io.LimitReader(response.Body, 256))
+		httpErr := internal.HTTPError{
 			Body:       string(buf),
 			StatusCode: response.StatusCode,
 		}
-		return "", time.Time{}, false, fmt.Errorf("unexpected HTTP status code: %w", err)
+		return "", time.Time{}, false, fmt.Errorf("unexpected HTTP status code: %w", httpErr)
 	}
 
 	gzReader, err := gzip.NewReader(response.Body)


### PR DESCRIPTION
On response status code error, geoipupdate puts whatever is read from the body into the message. That is, not only when err == nil