### PR TITLE
Dockerfile has a healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * When using the provided Docker images, `geoipupdate` no longer runs
   as root in the container. Pull request by Andreas Grünenfelder. GitHub
   #200.
+* The Dockerfile now has a Healthcheck that makes sure the modification date of
+  of the database directory is within the update period.
 
 ## 4.10.0 (2022-09-26)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,3 +7,11 @@ RUN adduser -D -h /var/lib/geoip -u 1000 geoip
 USER geoip
 WORKDIR /var/lib/geoip
 ENTRYPOINT ["/usr/bin/entry.sh"]
+
+# The health check is done by checking if the database directory is modified within the
+# update period minus 1 minute. The 1 minute is a threshold for allowing slower starts.
+# Without the LockFile in the database directory, this check is not going to be working
+# since database files are not going to be modified when there are no updates.
+HEALTHCHECK --interval=10s --timeout=10s \
+    CMD test $(stat -c %Y /usr/share/GeoIP) -gt $(($(date +%s) - $GEOIPUPDATE_FREQUENCY * 60 * 61 )) \
+    || exit 1;


### PR DESCRIPTION
This PR adds the Dockerfile a `HEALTHCHECK`, which passes when the modified date of the database directory is within the download period.