### PR TITLE
Add geoip user to drop root privileges

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,9 @@
-FROM alpine:3
+FROM docker.io/alpine:3
 
 COPY geoipupdate /usr/bin/geoipupdate
 COPY docker/entry.sh /usr/bin/entry.sh
-
-ENTRYPOINT ["/usr/bin/entry.sh"]
-
 VOLUME [ "/usr/share/GeoIP" ]
+RUN adduser -D -h /var/lib/geoip -u 1000 geoip
+USER geoip
+WORKDIR /var/lib/geoip
+ENTRYPOINT ["/usr/bin/entry.sh"]

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -14,7 +14,7 @@ term_handler() {
 trap 'kill ${!}; term_handler' SIGTERM
 
 pid=0
-conf_file=/etc/GeoIP.conf
+conf_file=/var/lib/geoip/GeoIP.conf
 database_dir=/usr/share/GeoIP
 flags=
 frequency=$((GEOIPUPDATE_FREQUENCY * 60 * 60))


### PR DESCRIPTION
Build container without requiring root privileges. Background is we're trying to run it in kubernetes with the restricted PodSecurityStandard policy enforced.