### PR TITLE
Release 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 5.0.1 (2023-04-13)
+
+* The 5.0.0 release mistakenly set the file permissions on downloaded
+  databases to 0600. This restores the previous behavior of using 0644.
+  Pull request by Josh Samuelson. GitHub #217 and #218.
+
 ## 5.0.0 (2023-04-12)
 
 * Redefined the `Reader` and `Writer` interface apis in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## 5.0.0 (2023-04-12)
 
-* Redefined the `Reader` and `Writer` interface apis in
+* Redefined the `Reader` and `Writer` interface APIs in
   `pkg/geoipupdate/database`. This change aims to to make it easier to
   introduce custom implementations of these interfaces.
 * Changed the signature of `NewConfig` in `pkg/geoipupdate` to accept

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 5.0.0 (2023-04-11)
+## 5.0.0 (2023-04-12)
 
 * Redefined the `Reader` and `Writer` interface apis in
   `pkg/geoipupdate/database`. This change aims to to make it easier to

--- a/README.dev.md
+++ b/README.dev.md
@@ -43,11 +43,3 @@ allow_unsigned_uploads = 0
 Then you can run the same `dput` command but with `dput maxmind [...]`
 instead of `dput ppa:maxmind/ppa [...]` (I'm not sure how to make the
 matching work with the original command).
-
-Finally release to Homebrew:
-
-* Go to https://github.com/Homebrew/homebrew-core/blob/master/Formula/geoipupdate.rb
-* Edit the file to update the url and sha256. You can get the sha256 for the
-  tarball with the `sha256sum` command line utility.
-* Make a commit with the summary `geoipupdate <VERSION>`
-* Submit a PR with the changes you just made.

--- a/README.dev.md
+++ b/README.dev.md
@@ -1,8 +1,7 @@
 # Releasing
 
-* Make sure you have [`hub`](https://github.com/github/hub),
-  [`goreleaser`](https://goreleaser.com/), rpmbuild, and pandoc installed.
-  (rpmbuild is in the Ubuntu package `rpm`).
+* Make sure you have [`goreleaser`](https://goreleaser.com/), rpmbuild,
+  and pandoc installed. (rpmbuild is in the Ubuntu package `rpm`).
 * Set release date in `CHANGELOG.md` and commit it.
 * Ensure you can run `docker` commands as your user (e.g., `docker
   images`).

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -61,8 +61,6 @@ $notes"
 
 git tag -a -m "$message" "$tag"
 
-# It's important to push before running any hub commands as hub works off
-# what's pushed.
 git push
 
 # goreleaser's `--rm-dist' should clear out `dist', but it didn't work for me.

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -49,7 +49,9 @@ if [ "$ok" != "y" ]; then
     exit 1
 fi
 
-git commit -m "Update for $tag" -a
+if [ -n "$(git status --porcelain)" ]; then
+    git commit -m "Update for $tag" -a
+fi
 
 git push
 

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -65,6 +65,6 @@ git tag -a -m "$message" "$tag"
 
 git push
 
-# goreleaser's `--rm-dist' should clear out `dist', but it didn't work for me.
+# goreleaser's `--clean' should clear out `dist', but it didn't work for me.
 rm -rf dist
-goreleaser release --rm-dist -f .goreleaser.yml --release-notes <(echo "$notes")
+goreleaser release --clean -f .goreleaser.yml --release-notes <(echo "$notes")

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -37,7 +37,7 @@ fi
 
 tag="v$version"
 
-perl -pi -e "s/(?<=Version = \").+?(?=\")/$version/g" pkg/geoipupdate/version.go
+perl -pi -e "s/(?<=Version = \").+?(?=\")/$version/g" pkg/geoipupdate/vars/version.go
 
 echo $'\nRelease notes:'
 echo "$notes"

--- a/pkg/geoipupdate/database/local_file_writer.go
+++ b/pkg/geoipupdate/database/local_file_writer.go
@@ -156,7 +156,7 @@ type fileWriter struct {
 func newFileWriter(path string) (*fileWriter, error) {
 	// prepare temp file for initial writing.
 	//nolint:gosec // we really need to read this file.
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("error creating temporary file at %s: %w", path, err)
 	}

--- a/pkg/geoipupdate/vars/version.go
+++ b/pkg/geoipupdate/vars/version.go
@@ -2,4 +2,4 @@
 package vars
 
 // Version defines current geoipupdate version.
-const Version = "5.0.0"
+const Version = "5.0.1"


### PR DESCRIPTION
- Update release date
- Remove outdated references to hub
- Update path for version.go
- Don't commit if repo is clean
- Update deprecated flag with new name
