### PR TITLE
Fix file permissions

### DIFF
--- a/pkg/geoipupdate/database/local_file_writer.go
+++ b/pkg/geoipupdate/database/local_file_writer.go
@@ -156,7 +156,7 @@ type fileWriter struct {
 func newFileWriter(path string) (*fileWriter, error) {
 	// prepare temp file for initial writing.
 	//nolint:gosec // we really need to read this file.
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("error creating temporary file at %s: %w", path, err)
 	}


### PR DESCRIPTION
This commit https://github.com/maxmind/geoipupdate/commit/9d71a711214dbd94c2fbe8781c535cc32055ce99 changed the file permissions to 0600 without explanation beyond "lint database package". This seems to be a mistake and it's breaking our builds.