### PR TITLE
Hide "Database up to date" messages behind verbose

### DIFF
--- a/pkg/geoipupdate/database/local_file_writer.go
+++ b/pkg/geoipupdate/database/local_file_writer.go
@@ -47,7 +47,7 @@ func NewLocalFileWriter(
 // Write writes the result struct returned by a Reader to a database file.
 func (w *LocalFileWriter) Write(result *ReadResult) error {
 	// exit early if we've got the latest database version.
-	if strings.EqualFold(result.oldHash, result.newHash) {
+	if w.verbose && strings.EqualFold(result.oldHash, result.newHash) {
 		log.Printf("Database %s up to date", result.editionID)
 		return nil
 	}


### PR DESCRIPTION
It's expected that many (if not most) will run geoipupdate from cron, so normal operation likely shouldn't produce any output.

When the database is updated, no output is produced unless verbose is enabled. However, when no update is available, a message is produced regardless of verbosity.

Make the output consistent by guarding "Database %s up to date" behind a verbose check.