### PR TITLE
Tag correct commit during release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -195,3 +195,4 @@ nfpms:
         type: config
 release:
   name_template: "{{.Version}}"
+  target_commitish: "{{ .Commit }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -195,4 +195,4 @@ nfpms:
         type: config
 release:
   name_template: "{{.Version}}"
-  target_commitish: "{{ .Commit }}"
+  target_commitish: "{{ .FullCommit }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 5.0.4 (2023-04-17)
+
+* On releases 4.9.0 through 5.0.3, the incorrect commit was tagged.
+  This release attempts to fix the release process to prevent this
+  issue. There are no code changes to the binaries provided by
+  MaxMind, either on the GitHub Release page or the MaxMind PPA.
+
 ## 5.0.3 (2023-04-15)
 
 * On 5.0.0 through 5.0.2, the default database directory was not being

--- a/pkg/geoipupdate/vars/version.go
+++ b/pkg/geoipupdate/vars/version.go
@@ -2,4 +2,4 @@
 package vars
 
 // Version defines current geoipupdate version.
-const Version = "5.0.3"
+const Version = "5.0.4"


### PR DESCRIPTION
Previously, `goreleaser` was just tagging the HEAD of the default branch.