### PR TITLE
Export database.ReadResult.Reader

### DIFF
--- a/pkg/geoipupdate/database/http_reader.go
+++ b/pkg/geoipupdate/database/http_reader.go
@@ -183,7 +183,7 @@ func (r *HTTPReader) get(
 	}
 
 	return &ReadResult{
-		reader:     gzReader,
+		Reader:     gzReader,
 		EditionID:  editionID,
 		OldHash:    hash,
 		NewHash:    newHash,

--- a/pkg/geoipupdate/database/http_reader_test.go
+++ b/pkg/geoipupdate/database/http_reader_test.go
@@ -38,7 +38,7 @@ func TestHTTPReader(t *testing.T) {
 			responseHash:   "cfa36ddc8279b5483a5aa25e9a6151f4",
 			responseTime:   testTime.Format(time.RFC1123),
 			result: &ReadResult{
-				reader:     getReader(t, "database content"),
+				Reader:     getReader(t, "database content"),
 				EditionID:  "GeoIP2-City",
 				OldHash:    "fbe1786bfd80e1db9dc42ddaff868f38",
 				NewHash:    "cfa36ddc8279b5483a5aa25e9a6151f4",
@@ -54,7 +54,7 @@ func TestHTTPReader(t *testing.T) {
 			responseHash:   "",
 			responseTime:   "",
 			result: &ReadResult{
-				reader:     nil,
+				Reader:     nil,
 				EditionID:  "GeoIP2-City",
 				OldHash:    "fbe1786bfd80e1db9dc42ddaff868f38",
 				NewHash:    "fbe1786bfd80e1db9dc42ddaff868f38",
@@ -133,12 +133,12 @@ func TestHTTPReader(t *testing.T) {
 				require.Equal(t, result.NewHash, test.result.NewHash)
 				require.Equal(t, result.ModifiedAt, test.result.ModifiedAt)
 
-				if test.result.reader != nil && result.reader != nil {
-					defer result.reader.Close()
-					defer test.result.reader.Close()
-					resultDatabase, err := io.ReadAll(test.result.reader)
+				if test.result.Reader != nil && result.Reader != nil {
+					defer result.Reader.Close()
+					defer test.result.Reader.Close()
+					resultDatabase, err := io.ReadAll(test.result.Reader)
 					require.NoError(t, err)
-					expectedDatabase, err := io.ReadAll(result.reader)
+					expectedDatabase, err := io.ReadAll(result.Reader)
 					require.NoError(t, err)
 					require.Equal(t, resultDatabase, expectedDatabase)
 				}

--- a/pkg/geoipupdate/database/local_file_writer.go
+++ b/pkg/geoipupdate/database/local_file_writer.go
@@ -55,7 +55,7 @@ func (w *LocalFileWriter) Write(result *ReadResult) error {
 	}
 
 	defer func() {
-		if err := result.reader.Close(); err != nil {
+		if err := result.Reader.Close(); err != nil {
 			log.Printf("closing reader for %s: %+v", result.EditionID, err)
 		}
 	}()
@@ -73,7 +73,7 @@ func (w *LocalFileWriter) Write(result *ReadResult) error {
 		}
 	}()
 
-	if err := fw.write(result.reader); err != nil {
+	if err := fw.write(result.Reader); err != nil {
 		return fmt.Errorf("writing to the temp file for %s: %w", result.EditionID, err)
 	}
 

--- a/pkg/geoipupdate/database/local_file_writer_test.go
+++ b/pkg/geoipupdate/database/local_file_writer_test.go
@@ -27,7 +27,7 @@ func TestLocalFileWriterWrite(t *testing.T) {
 			preserveFileTime: true,
 			checkTime:        require.Equal,
 			result: &ReadResult{
-				reader:     getReader(t, "database content"),
+				Reader:     getReader(t, "database content"),
 				EditionID:  "GeoIP2-City",
 				OldHash:    "",
 				NewHash:    "cfa36ddc8279b5483a5aa25e9a6151f4",
@@ -39,7 +39,7 @@ func TestLocalFileWriterWrite(t *testing.T) {
 			preserveFileTime: true,
 			checkTime:        require.Equal,
 			result: &ReadResult{
-				reader:     getReader(t, "database content"),
+				Reader:     getReader(t, "database content"),
 				EditionID:  "GeoIP2-City",
 				OldHash:    "",
 				NewHash:    "badhash",
@@ -51,7 +51,7 @@ func TestLocalFileWriterWrite(t *testing.T) {
 			preserveFileTime: true,
 			checkTime:        require.Equal,
 			result: &ReadResult{
-				reader:     getReader(t, "database content"),
+				Reader:     getReader(t, "database content"),
 				EditionID:  "GeoIP2-City",
 				OldHash:    "",
 				NewHash:    "cfa36ddc8279b5483a5aa25e9a6151f4",
@@ -63,7 +63,7 @@ func TestLocalFileWriterWrite(t *testing.T) {
 			preserveFileTime: false,
 			checkTime:        require.NotEqual,
 			result: &ReadResult{
-				reader:     getReader(t, "database content"),
+				Reader:     getReader(t, "database content"),
 				EditionID:  "GeoIP2-City",
 				OldHash:    "",
 				NewHash:    "CFA36DDC8279B5483A5AA25E9A6151F4",
@@ -75,7 +75,7 @@ func TestLocalFileWriterWrite(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			tempDir := t.TempDir()
-			defer test.result.reader.Close()
+			defer test.result.Reader.Close()
 
 			fw, err := NewLocalFileWriter(tempDir, test.preserveFileTime, false)
 			require.NoError(t, err)
@@ -95,7 +95,7 @@ func TestLocalFileWriterWrite(t *testing.T) {
 // TestLocalFileWriterGetHash tests functionality of the LocalFileWriter.GetHash method.
 func TestLocalFileWriterGetHash(t *testing.T) {
 	result := &ReadResult{
-		reader:     getReader(t, "database content"),
+		Reader:     getReader(t, "database content"),
 		EditionID:  "GeoIP2-City",
 		OldHash:    "",
 		NewHash:    "cfa36ddc8279b5483a5aa25e9a6151f4",
@@ -104,7 +104,7 @@ func TestLocalFileWriterGetHash(t *testing.T) {
 
 	tempDir := t.TempDir()
 
-	defer result.reader.Close()
+	defer result.Reader.Close()
 
 	fw, err := NewLocalFileWriter(tempDir, false, false)
 	require.NoError(t, err)

--- a/pkg/geoipupdate/database/reader.go
+++ b/pkg/geoipupdate/database/reader.go
@@ -16,12 +16,12 @@ type Reader interface {
 
 // ReadResult is the struct returned by a Reader's Get method.
 type ReadResult struct {
-	reader     io.ReadCloser
-	EditionID  string    `json:"edition_id"`
-	OldHash    string    `json:"old_hash"`
-	NewHash    string    `json:"new_hash"`
-	ModifiedAt time.Time `json:"modified_at"`
-	CheckedAt  time.Time `json:"checked_at"`
+	Reader     io.ReadCloser `json:"-"`
+	EditionID  string        `json:"edition_id"`
+	OldHash    string        `json:"old_hash"`
+	NewHash    string        `json:"new_hash"`
+	ModifiedAt time.Time     `json:"modified_at"`
+	CheckedAt  time.Time     `json:"checked_at"`
 }
 
 // MarshalJSON is a custom json marshaler that strips out zero time fields.


### PR DESCRIPTION
Export database.ReadResult.Reader, so alternate implementations can be used.

Currently the field is not exported so only the `LocalFileWriter` implementation in the same package is able to read out the data. Creating new writer implementations outside of the package is impossible without this change.