### PR TITLE
Fix modify http.DefaultTransport

### DIFF
--- a/pkg/geoipupdate/database/http_reader.go
+++ b/pkg/geoipupdate/database/http_reader.go
@@ -48,10 +48,9 @@ func NewHTTPReader(
 	retryFor time.Duration,
 	verbose bool,
 ) Reader {
-	transport := http.DefaultTransport
+	transport := &http.Transport{Proxy: http.ProxyFromEnvironment}
 	if proxy != nil {
-		proxyFunc := http.ProxyURL(proxy)
-		transport.(*http.Transport).Proxy = proxyFunc
+		transport.Proxy = http.ProxyURL(proxy)
 	}
 
 	return &HTTPReader{


### PR DESCRIPTION
Original logic modify `http.DefualtTransport` Proxy Settings.

Use the library, developer won't realize proxy settings, (runtime) global proxy settings is changed