### PR TITLE
Configuration file for geoipupdate is actually optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   such as HTTP2 INTERNAL_ERROR.
 * `HTTPReader` no longer retries on HTTP errors and therefore
   `retryFor` was removed from `NewHTTPReader`.
+* Now `geoipupdate` doesn't requires the user to specify the config file
+  even if all the other arguments are set via the environment variables.
+  Reported by jsf84ksnf. GitHub #284.
 
 ## 6.1.0 (2024-01-09)
 

--- a/cmd/geoipupdate/args.go
+++ b/cmd/geoipupdate/args.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 	"os"
 
@@ -19,6 +20,13 @@ type Args struct {
 
 func getArgs() *Args {
 	confFileDefault := vars.DefaultConfigFile
+	// Set the default config file only if it exists.
+	// Othwerwise, geoipupdate requires the user to specify the config file
+	// even if all the other arguments are set via the environment variables.
+	if _, err := os.Stat(confFileDefault); errors.Is(err, os.ErrNotExist) {
+		confFileDefault = ""
+	}
+
 	if value, ok := os.LookupEnv("GEOIPUPDATE_CONF_FILE"); ok {
 		confFileDefault = value
 	}


### PR DESCRIPTION
See https://github.com/maxmind/geoipupdate/issues/284.

```sh
$ export GEOIPUPDATE_ACCOUNT_ID='123'
$ export GEOIPUPDATE_LICENSE_KEY='456'
$ export GEOIPUPDATE_EDITION_IDS='GeoIP2-Enterprise GeoLite2-ASN GeoLite2-City GeoLite2-Country'
$ export GEOIPUPDATE_DB_DIR='/my/path/to/db'
$ touch blank
$ go run ./cmd/geoipupdate/ -f=blank
```