### PR TITLE
Ignore dist dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 /build
+/dist
 /cmd/geoipupdate/geoipupdate
 /vendor
 .idea


### PR DESCRIPTION
So that the Git repo does not show up as dirty in the build info.
