### PR TITLE
Respect host scheme if set

### DIFF
--- a/conf/GeoIP.conf.default
+++ b/conf/GeoIP.conf.default
@@ -17,8 +17,8 @@ EditionIDs GeoLite2-Country GeoLite2-City
 # The directory to store the database files. Defaults to DATADIR
 # DatabaseDirectory DATADIR
 
-# The server to use. Defaults to "updates.maxmind.com".
-# Host updates.maxmind.com
+# The server to use. Defaults to "https://updates.maxmind.com".
+# Host https://updates.maxmind.com
 
 # The proxy host name or IP address. You may optionally specify a
 # port number, e.g., 127.0.0.1:8888. If no port number is specified, 1080

--- a/doc/GeoIP.conf.md
+++ b/doc/GeoIP.conf.md
@@ -45,7 +45,7 @@ sensitive.
 
 `Host`
 
-:   The host name of the server to use. The default is `updates.maxmind.com`.
+:   The host name of the server to use. The default is `https://updates.maxmind.com`.
     This can be overridden at run time by the `GEOIPUPDATE_HOST` environment
     variable.
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -30,7 +30,7 @@ The following are optional:
 * `GEOIPUPDATE_FREQUENCY` - The number of hours between `geoipupdate` runs.
   If this is not set or is set to `0`, `geoipupdate` will run once and exit.
 * `GEOIPUPDATE_HOST` - The host name of the server to use. The default is
-  `updates.maxmind.com`.
+  `https://updates.maxmind.com`.
 * `GEOIPUPDATE_PROXY` - The proxy host name or IP address. You may optionally
   specify a port number, e.g., 127.0.0.1:8888. If no port number is specified,
   1080 will be used.

--- a/internal/geoipupdate/config_test.go
+++ b/internal/geoipupdate/config_test.go
@@ -464,6 +464,20 @@ EditionIDs    GeoLite2-City      GeoLite2-Country
 				Verbose:  true,
 			},
 		},
+		{
+			Description: "Host scheme is used",
+			Input:       "AccountID\t\t123\nLicenseKey\t\t456\nEditionIDs\t\tGeoIP2-City\nHost\t\thttp://test",
+			Output: &Config{
+				AccountID:         123,
+				DatabaseDirectory: filepath.Clean(vars.DefaultDatabaseDirectory),
+				EditionIDs:        []string{"GeoIP2-City"},
+				LicenseKey:        "456",
+				LockFile:          filepath.Clean(filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock")),
+				RetryFor:          5 * time.Minute,
+				Parallelism:       1,
+				URL:               "http://test",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Hi!

This PR changes the `Host` config and `GEOIPUPDATE_HOST` env to respect the scheme if set. If not set, behavior is unchanged and the scheme will default to `https://`. A nice side-effect is that the `url.Parse()` step will cause the host value to be validated during the config load phase. I also updated the docs to reflect that the default value is `https://`, but since it's optional, feel free to let me know if you'd prefer to keep these unchanged.

For some background, I have a local Kubernetes job which requires a GeoIP database. I'd prefer to avoid attaching storage for reliability, but I don't want to fetch the database each run. I built an internal service which proxies the GeoIP API and caches the response for a time, and would rather keep communication internal without requiring proxies or HTTPS certificates.

Thank you!