### PR TITLE
Fixes for new golangci-lint

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -112,18 +112,6 @@ disable = [
     # This would probably be good, but we would need to configure it.
     "wsl",
 
-    # These are all deprecated
-    "deadcode",
-    "exhaustivestruct",
-    "golint",
-    "ifshort",
-    "interfacer",
-    "maligned",
-    "nosnakecase",
-    "scopelint",
-    "structcheck",
-    "varcheck",
-
     # Require Go 1.22
     "copyloopvar",
     "intrange",
@@ -166,11 +154,6 @@ exclude-functions = [
     'os.Remove',
     'os.RemoveAll',
 ]
-
-# Ignoring Close so that we don't have to have a bunch of
-# `defer func() { _ = r.Close() }()` constructs when we
-# don't actually care about the error.
-ignore = "Close,fmt:.*"
 
 [linters-settings.errorlint]
 errorf = true
@@ -618,6 +601,16 @@ linters = [
     "wrapcheck",
 ]
 path = "_test.go"
+
+[[issues.exclude-rules]]
+linters = [
+    "errcheck",
+]
+# There are many cases where we want to just close resources and ignore the
+# error (e.g., for defer f.Close on a read). errcheck removed its built-in
+# wildcard ignore. I tried listing all of the cases, but it was too many
+# and some were very specific.
+source = "\\.Close"
 
 [[issues.exclude-rules]]
 linters = [

--- a/client/download_test.go
+++ b/client/download_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,7 +38,7 @@ func TestDownload(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte(jsonData))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 
 	tests := []struct {
@@ -61,18 +62,26 @@ func TestDownload(t *testing.T) {
 					}
 
 					err := tw.WriteHeader(header)
-					require.NoError(t, err)
+					if !assert.NoError(t, err) {
+						return
+					}
 					_, err = tw.Write([]byte(dbContent))
-					require.NoError(t, err)
+					if !assert.NoError(t, err) {
+						return
+					}
 
-					require.NoError(t, tw.Close())
-					require.NoError(t, gw.Close())
+					if !assert.NoError(t, tw.Close()) {
+						return
+					}
+					if !assert.NoError(t, gw.Close()) {
+						return
+					}
 
 					w.Header().Set("Content-Type", "application/gzip")
 					w.Header().Set("Content-Disposition", "attachment; filename=test.tar.gz")
 					w.Header().Set("Last-Modified", lastModified.Format(time.RFC1123))
 					_, err = io.Copy(w, &buf)
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				})
 
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -128,7 +137,7 @@ func TestDownload(t *testing.T) {
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusOK)
 					_, err := w.Write([]byte(jsonData))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				return server
 			},
@@ -145,13 +154,17 @@ func TestDownload(t *testing.T) {
 					var buf bytes.Buffer
 					gw := gzip.NewWriter(&buf)
 					tw := tar.NewWriter(gw)
-					require.NoError(t, tw.Close())
-					require.NoError(t, gw.Close())
+					if !assert.NoError(t, tw.Close()) {
+						return
+					}
+					if !assert.NoError(t, gw.Close()) {
+						return
+					}
 
 					w.Header().Set("Content-Type", "application/gzip")
 					w.Header().Set("Content-Disposition", "attachment; filename=test.tar.gz")
 					_, err := io.Copy(w, &buf)
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				})
 
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -185,17 +198,25 @@ func TestDownload(t *testing.T) {
 					}
 
 					err := tw.WriteHeader(header)
-					require.NoError(t, err)
+					if !assert.NoError(t, err) {
+						return
+					}
 					_, err = tw.Write([]byte(dbContent))
-					require.NoError(t, err)
+					if !assert.NoError(t, err) {
+						return
+					}
 
-					require.NoError(t, tw.Close())
-					require.NoError(t, gw.Close())
+					if !assert.NoError(t, tw.Close()) {
+						return
+					}
+					if !assert.NoError(t, gw.Close()) {
+						return
+					}
 
 					w.Header().Set("Content-Type", "application/gzip")
 					w.Header().Set("Content-Disposition", "attachment; filename=test.tar.gz")
 					_, err = io.Copy(w, &buf)
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				})
 
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/client/metadata_test.go
+++ b/client/metadata_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,7 +33,7 @@ func TestGetMetadata(t *testing.T) {
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusOK)
 					_, err := w.Write([]byte(jsonData))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				return server
 			},

--- a/cmd/geoipupdate/end_to_end_test.go
+++ b/cmd/geoipupdate/end_to_end_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/maxmind/geoipupdate/v7/internal/geoipupdate"
@@ -43,7 +44,9 @@ func TestUpdater(t *testing.T) {
 	// mock metadata handler.
 	metadataHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		queryParams, err := url.ParseQuery(r.URL.RawQuery)
-		require.NoError(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 
 		var jsonData string
 		switch queryParams.Get("edition_id") {
@@ -74,7 +77,7 @@ func TestUpdater(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, err = w.Write([]byte(jsonData))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 
 	// mock download handler.
@@ -92,18 +95,26 @@ func TestUpdater(t *testing.T) {
 		}
 
 		err := tw.WriteHeader(header)
-		require.NoError(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 		_, err = tw.Write([]byte(content))
-		require.NoError(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 
-		require.NoError(t, tw.Close())
-		require.NoError(t, gw.Close())
+		if !assert.NoError(t, tw.Close()) {
+			return
+		}
+		if !assert.NoError(t, gw.Close()) {
+			return
+		}
 
 		w.Header().Set("Content-Type", "application/gzip")
 		w.Header().Set("Content-Disposition", "attachment; filename=test.tar.gz")
 		w.Header().Set("Last-Modified", lastModified.Format(time.RFC1123))
 		_, err = io.Copy(w, &buf)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 
 	// create test server.

--- a/internal/geoipupdate/geoip_updater_test.go
+++ b/internal/geoipupdate/geoip_updater_test.go
@@ -146,7 +146,7 @@ func TestRetryWhenWriting(t *testing.T) {
 				`{"databases":[{"edition_id":"foo-db-name",` +
 					`"md5":"83e01ba43c2a66e30cb3007c1a300c78","date":"2023-04-27"}]}`)
 			_, err := w.Write(metadata)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			return
 		}
@@ -163,12 +163,16 @@ func TestRetryWhenWriting(t *testing.T) {
 			size: 1000,
 		}
 		header, err := tar.FileInfoHeader(info, info.Name())
-		require.NoError(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 		header.Name = "foo-db-name.mmdb"
 
 		// Create a tar Header from the FileInfo data
 		err = tarWriter.WriteHeader(header)
-		require.NoError(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 
 		bytesToWrite := 1000
 		if try == 0 {
@@ -179,7 +183,9 @@ func TestRetryWhenWriting(t *testing.T) {
 
 		for i := 0; i < bytesToWrite; i++ {
 			_, err = tarWriter.Write([]byte("t"))
-			require.NoError(t, err)
+			if !assert.NoError(t, err) {
+				return
+			}
 		}
 		try++
 	}))


### PR DESCRIPTION
- **Do not require from HTTP handlers**
- **Update golangci-lint config**
