### PR TITLE
Export HTTPError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   environment variable to accept a value with the scheme set. If not set, it
   will continue to default to `https://`. Pull request by Gabe Cook. GitHub
   #310.
+* Export `HTTPError` to enable fine-grained error handling for users of
+  `github.com/maxmind/geoipupdate/client`. Pull request by Ryan Davis. GitHub
+  #341.
 
 ## 7.0.1 (2024-04-08)
 

--- a/client/download.go
+++ b/client/download.go
@@ -17,6 +17,11 @@ import (
 	"github.com/maxmind/geoipupdate/v7/internal/vars"
 )
 
+// HTTPError is an error from performing an HTTP request and receiving a non-200 status code.
+//
+// See https://dev.maxmind.com/geoip/docs/web-services/responses/#errors for more details.
+type HTTPError = internal.HTTPError
+
 // DownloadResponse describes the result of a Download call.
 type DownloadResponse struct {
 	// LastModified is the date that the database was last modified. It will
@@ -55,6 +60,9 @@ type DownloadResponse struct {
 //
 // If the current MD5 checksum matches what the server currently has, no
 // download is performed.
+//
+// Returns an [HTTPError] if the server returns a non-200 status code. This
+// can be used to identify problems with license.
 func (c Client) Download(
 	ctx context.Context,
 	editionID,
@@ -125,7 +133,7 @@ func (c *Client) download(
 		// TODO(horgh): Should we fully consume the body?
 		//nolint:errcheck // we are already returning an error.
 		buf, _ := io.ReadAll(io.LimitReader(response.Body, 256))
-		httpErr := internal.HTTPError{
+		httpErr := HTTPError{
 			Body:       string(buf),
 			StatusCode: response.StatusCode,
 		}

--- a/client/metadata.go
+++ b/client/metadata.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/maxmind/geoipupdate/v7/internal"
 	"github.com/maxmind/geoipupdate/v7/internal/vars"
 )
 
@@ -51,7 +50,7 @@ func (c *Client) getMetadata(
 	}
 
 	if response.StatusCode != http.StatusOK {
-		httpErr := internal.HTTPError{
+		httpErr := HTTPError{
 			Body:       string(responseBody),
 			StatusCode: response.StatusCode,
 		}


### PR DESCRIPTION
Lets callers use `errors.As` to differentiate transient outages from license problems.

fixes #341