### PR TITLE
Fix golangci-lint build

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -166,9 +166,6 @@ linters-settings:
       - os.Remove
       - os.RemoveAll
 
-    # This is a workaround for https://github.com/golangci/golangci-lint/issues/4733
-    ignore: ""
-
   errorlint:
     errorf: true
     asserts: true


### PR DESCRIPTION
- **Require Go 1.23 and test on 1.24**
- **Refresh golangci-lint config and convert to YAML**
- **Upgrade to github.com/cenkalti/backoff/v5**
- **Remove workaround**
