### PR TITLE
Upgrade to golangci-lint v2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           persist-credentials: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,12 @@
+version: "2"
 run:
   # This is needed for precious, which may run multiple instances
   # in parallel
-  allow-parallel-runners: true
   go: "1.23"
   tests: true
-  timeout: "30m"
-
+  allow-parallel-runners: true
 linters:
-  enable-all: true
+  default: all
   disable:
     # The canonical form is not always the most common form for some headers
     # and there is a small chance that switching existing strings could
@@ -15,11 +14,21 @@ linters:
     - canonicalheader
 
     - cyclop
+
+    # This forbids stuff like "_, _, _, err := ...". Although I agree that it
+    # is not ideal, the actual uses in our code-base are mostly due to third-
+    # party libraries.
     - dogsled
+
+    # This seems to primarily go off for table-driven tests for us. I don't
+    # know if more sharing between these tests would actually make the code
+    # easier to follow.
     - dupl
 
-    # This is probably worthwhile, but there are a number of false positives
-    # that would need to be addressed.
+    # This is very helpful for linting comments, but for strings in code it
+    # is pretty questionable, e.g., we have repeated strings in GeoIP build
+    # code for org names or in test cases. We should consider enabling if
+    # they allow limiting it to certain cases in the future.
     - dupword
 
     # We don't follow its policy about not defining dynamic errors.
@@ -43,6 +52,8 @@ linters:
     - gochecksumtype
 
     - gocognit
+
+    # We don't want to forbid TODO, FIXME, etc.
     - godox
 
     # This only "caught" one thing, and it seemed like a reasonable use
@@ -55,10 +66,12 @@ linters:
     # interfaces we have.
     - inamedparam
 
+    # This is an ok rule generally, but we don't return that many interfaces
+    # and where we do, we tend to have a particular reason to do so.
     - ireturn
 
-    # We don't use these loggers
-    - loggercheck
+    # We use golines instead.
+    - lll
 
     # Maintainability Index. Seems like it could be a good idea, but a
     # lot of things fail and we would need to make some decisions about
@@ -74,9 +87,13 @@ linters:
 
     - nestif
 
-    # Perhaps too opinionated. We do have some legitimate uses of "return nil, nil"
+    # We do end up with a lot of debates on PRs about nil, nil returns. Such
+    # returns are often surprising, but there seem to be enough valid cases
+    # in our codebase that I am reluctant to enforce this.
     - nilnil
 
+    # Checks for a new line before a return. Although that often seems helpful,
+    # there are many cases where it is not.
     - nlreturn
 
     # We occasionally use named returns for documentation, which is helpful.
@@ -85,535 +102,636 @@ linters:
     # case.
     - nonamedreturns
 
+    # This is not something we want to enforce throughout our code.
     - paralleltest
+
+    # This seems like premature optimization for most programs.
     - prealloc
 
     # We have very few structs with multiple tags and for the couple we had, this
     # actually made it harder to read.
     - tagalign
-
-    # Deprecated since golangci-lint 1.64.0. The usetesting linter replaces it.
-    - tenv
-
-    # We probably _should_ be doing this!
-    - thelper
-
     # We don't follow this. Sometimes we test internal code.
     - testpackage
-
+    # We probably _should_ be doing this!
+    - thelper
     - varnamelen
 
-    # This would probably be good, but we would need to configure it.
+    # Although some fixes in this seem good (e.g., err cuddling), I was
+    # not able to disable some of the less desirable whitespace changes.
     - wsl
 
-linters-settings:
-  # Please note that we only use depguard for blocking packages and
-  # gomodguard for blocking modules.
-  depguard:
-    rules:
-      main:
-        deny:
-          - pkg: github.com/likexian/gokit/assert
-            desc: Use github.com/stretchr/testify/assert
-
-          - pkg: golang.org/x/exp/maps
-            desc: Use maps instead.
-
-          - pkg: golang.org/x/exp/slices
-            desc: Use slices instead.
-
-          - pkg: golang.org/x/exp/slog
-            desc: Use log/slog instead.
-
-          - pkg: google.golang.org/api/compute/v1
-            desc: Use cloud.google.com/go/compute/apiv1 instead.
-
-          - pkg: google.golang.org/api/cloudresourcemanager/v1
-            desc: Use cloud.google.com/go/resourcemanager/apiv3 instead.
-
-          - pkg: google.golang.org/api/serviceusage/v1
-            desc: Use cloud.google.com/go/serviceusage/apiv1 instead.
-
-          - pkg: io/ioutil
-            desc: Deprecated. Functions have been moved elsewhere.
-
-          - pkg: k8s.io/utils/strings/slices
-            desc: Use slices
-
-          - pkg: math/rand$
-            desc: Use math/rand/v2 or crypto/rand as appropriate.
-
-          - pkg: sort
-            desc: Use slices instead
-
-  errcheck:
-    # Don't allow setting of error to the blank identifier. If there is a legitimate
-    # reason, there should be a nolint with an explanation.
-    check-blank: true
-
-    exclude-functions:
-      # If we are rolling back a transaction, we are often already in an error
-      # state.
-      - (*database/sql.Tx).Rollback
-
-      # It is reasonable to ignore errors if Cleanup fails in most cases.
-      - (*github.com/google/renameio/v2.PendingFile).Cleanup
-
-      # We often do not care if unlocking failed as we are exiting anyway.
-      - (*github.com/gofrs/flock.Flock).Unlock
-
-      # We often don't care if removing a file failed (e.g., it doesn't exist)
-      - os.Remove
-      - os.RemoveAll
-
-  errorlint:
-    errorf: true
-    asserts: true
-    comparison: true
-
-  exhaustive:
-    default-signifies-exhaustive: true
-
-  forbidigo:
-    # Forbid the following identifiers
-    forbid:
-      - p: Geoip
-        msg: you should use the `GeoIP` qualifier instead
-      - p: geoIP
-        msg: you should use the `geoip` qualifier instead
-      - p: ^hubSpot
-        msg: you should use the `hubspot` qualifier instead
-      - p: Maxmind
-        msg: you should use the `MaxMind` qualifier instead
-      - p: ^maxMind
-        msg: you should use the `maxmind` qualifier instead
-      - p: Minfraud
-        msg: you should use the `MinFraud` qualifier instead
-      - p: ^minFraud
-        msg: you should use the `minfraud` qualifier instead
-      - p: "[Uu]ser[iI][dD]"
-        msg: you should use the `accountID` or the `AccountID` qualifier instead
-      - p: WithEnterpriseURLs
-        msg: Use ghe.NewClient instead.
-      - p: ^bigquery.NewClient
-        msg: you should use mmgcloud.NewBigQueryClient instead.
-      - p: ^drive.NewService
-        msg: you should use mmgdrive.NewGDrive instead.
-      - p: ^filepath.Walk$
-        msg: you should use filepath.WalkDir instead as it doesn't call os.Lstat on every entry.
-      - p: ^math.Max$
-        msg: you should use the max built-in instead.
-      - p: ^math.Min$
-        msg: you should use the min built-in instead.
-      - p: ^mux.Vars$
-        msg: use req.PathValue instead.
-      - p: ^net.ParseCIDR
-        msg: you should use netip.ParsePrefix unless you really need a *net.IPNet
-      - p: ^net.ParseIP
-        msg: you should use netip.ParseAddr unless you really need a net.IP
-      - p: ^pgtype.NewMap
-        msg: you should use mmdatabase.NewTypeMap instead
-      - p: ^sheets.NewService
-        msg: you should use mmgcloud.NewSheetsService instead.
-      - p: ^storage.NewClient
-        msg: you should use gstorage.NewClient instead. This sets the HTTP client settings that we need for internal use.
-      - p: ^os.IsNotExist
-        msg: As per their docs, new code should use errors.Is(err, fs.ErrNotExist).
-      - p: ^os.IsExist
-        msg: As per their docs, new code should use errors.Is(err, fs.ErrExist)
-      - p: ^net.LookupIP
-        msg: You should use net.Resolver functions instead.
-      - p: ^net.LookupCNAME
-        msg: You should use net.Resolver functions instead.
-      - p: ^net.LookupHost
-        msg: You should use net.Resolver functions instead.
-      - p: ^net.LookupPort
-        msg: You should use net.Resolver functions instead.
-      - p: ^net.LookupTXT
-        msg: You should use net.Resolver functions instead.
-      - p: ^net.LookupAddr
-        msg: You should use net.Resolver functions instead.
-      - p: ^net.LookupMX
-        msg: You should use net.Resolver functions instead.
-      - p: ^net.LookupNS
-        msg: You should use net.Resolver functions instead.
-      - p: ^net.LookupSRV
-        msg: You should use net.Resolver functions instead.
-
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/maxmind/geoipupdate/v7)
-
-  gocritic:
-    enable-all: true
-    disabled-checks:
-      # Revive's defer rule already captures this. This caught no extra cases.
-      - deferInLoop
-      # Given that all of our code runs on Linux and the / separate should
-      # work fine, this seems less important.
-      - filepathJoin
-      # This seems like it could be good, but we would need to update current
-      # uses. It supports "--fix", but the fixing is a bit broken.
-      - httpNoBody
-      # This might be good, but we would have to revisit a lot of code.
-      - hugeParam
-      # This might be good, but I don't think we want to encourage
-      # significant changes to regexes as we port stuff from Perl.
-      - regexpSimplify
-      # This seems like it might also be good, but a lot of existing code
-      # fails.
-      - sloppyReassign
-      # I am not sure we would want this linter and a lot of existing
-      # code fails.
-      - unnamedResult
-      # Covered by nolintlint
-      - whyNoLint
-
-  gofumpt:
-    extra-rules: true
-
-  # IMPORTANT: gomodguard blocks _modules_, not arbitrary packages. Be
-  # sure to use the module path from the go.mod file for these.
-  # See https://github.com/ryancurrah/gomodguard/issues/12
-  gomodguard:
-    blocked:
-      modules:
-        - github.com/avct/uasurfer:
-            recommendations:
-              - github.com/xavivars/uasurfer
-            reason: The original avct module appears abandoned.
-        - github.com/BurntSushi/toml:
-            recommendations:
-              - github.com/pelletier/go-toml/v2
-            reason: This library panics frequently on invalid input.
-        - github.com/pelletier/go-toml:
-            recommendations:
-              - github.com/pelletier/go-toml/v2
-            reason: This is an outdated version.
-        - github.com/gofrs/uuid:
-            recommendations:
-              - github.com/google/uuid
-        - github.com/gofrs/uuid/v5:
-            recommendations:
-              - github.com/google/uuid
-        - github.com/satori/go.uuid:
-            recommendations:
-              - github.com/google/uuid
-        - github.com/lib/pq:
-            recommendations:
-              - github.com/jackc/pgx
-            reason: This library is no longer actively maintained.
-        - github.com/neilotoole/errgroup:
-            recommendations:
-              - golang.org/x/sync/errgroup
-            reason: This library can lead to subtle deadlocks in certain use cases.
-        - github.com/pariz/gountries:
-            reason: This library's data is not actively maintained. Use GeoInfo data.
-          github.com/pkg/errors:
-            reason: pkg/errors is no longer maintained.
-        - github.com/RackSec/srslog:
-            recommendations:
-              - log/syslog
-            reason: This library's data is not actively maintained.
-        - github.com/ua-parser/uap-go:
-            recommendations:
-              - github.com/xavivars/uasurfer
-            reason: The performance of this library is absolutely abysmal.
-        - github.com/ugorji/go:
-            recommendations:
-              - encoding/json
-              - github.com/mailru/easyjson
-            reason: This library is poorly maintained. We should default to using encoding/json and use easyjson where performance really matters.
-        - github.com/zeebo/assert:
-            recommendations:
-              - github.com/stretchr/testify/assert
-            reason: Use github.com/stretchr/testify/assert
-        - gotest.tools/v3:
-            recommendations:
-              - github.com/stretchr/testify/assert
-            reason: Use github.com/stretchr/testify/assert
-        - inet.af/netaddr:
-            recommendations:
-              - net/netip
-              - go4.org/netipx
-            reason: inet.af/netaddr has been deprecated.
-      versions:
-        - github.com/jackc/pgconn:
-            reason: Use github.com/jackc/pgx/v5
-        - github.com/jackc/pgtype:
-            reason: Use github.com/jackc/pgx/v5
-        - github.com/jackc/pgx:
-            version: < 5.0.0
-            reason: Use github.com/jackc/pgx/v5
-
-  gosec:
-    excludes:
-      # G104 - "Audit errors not checked." We use errcheck for this.
-      - G104
-
-      # G306 - "Expect WriteFile permissions to be 0600 or less".
-      - G306
-
-      # Prohibits defer (*os.File).Close, which we allow when reading from file.
-      - G307
-
-      # We use md5 in geoipupdate
-      - G401
-      - G501
-
-      # no longer relevant with 1.22
-      - G601
-
-  govet:
-    enable-all: true
-    # Although it is very useful in particular cases where we are trying to
-    # use as little memory as possible, there are even more cases where
-    # other organizations may make more sense.
-    disable:
-      - fieldalignment
-    settings:
-      shadow:
-        strict: true
-  lll:
-    line-length: 120
-    tab-width: 4
-
-  misspell:
-    locale: "US"
-    extra-words:
-      - typo: "marshall"
-        correction: "marshal"
-      - typo: "marshalling"
-        correction: "marshaling"
-      - typo: "marshalls"
-        correction: "marshals"
-      - typo: "unmarshall"
-        correction: "unmarshal"
-      - typo: "unmarshalling"
-        correction: "unmarshaling"
-      - typo: "unmarshalls"
-        correction: "unmarshals"
-
-  nolintlint:
-    allow-unused: false
-    allow-no-explanation: ["lll", "misspell"]
-    require-explanation: true
-    require-specific: true
-
-  revive:
-    enable-all-rules: true
-    ignore-generated-header: true
-    severity: "warning"
-
-    rules:
-      # This might be nice but it is so common that it is hard
-      # to enable.
-      - name: "add-constant"
-        disabled: true
-
-      - name: "argument-limit"
-        disabled: true
-
-      - name: "cognitive-complexity"
-        disabled: true
-
-      - name: "comment-spacings"
-        arguments: ["easyjson", "nolint"]
-        disabled: false
-
-      # Probably a good rule, but we have a lot of names that
-      # only have case differences.
-      - name: "confusing-naming"
-        disabled: true
-
-      - name: "cyclomatic"
-        disabled: true
-
-      # Although being consistent might be nice, I don't know that it
-      # is worth the effort enabling this rule. It doesn't have an
-      # autofix option.
-      - name: "enforce-repeated-arg-type-style"
-        arguments: ["short"]
-        disabled: true
-
-      - name: "enforce-map-style"
-        arguments: ["literal"]
-        disabled: false
-
-      # We have very few of these as we force nil slices in most places,
-      # but there are a couple of cases.
-      - name: "enforce-slice-style"
-        arguments: ["literal"]
-        disabled: false
-
-      - name: "file-header"
-        disabled: true
-
-      # We have a lot of flag parameters. This linter probably makes
-      # a good point, but we would need some cleanup or a lot of nolints.
-      - name: "flag-parameter"
-        disabled: true
-
-      - name: "function-length"
-        disabled: true
-
-      - name: "function-result-limit"
-        disabled: true
-
-      - name: "line-length-limit"
-        disabled: true
-
-      - name: "max-public-structs"
-        disabled: true
-
-      # We frequently use nested structs, particularly in tests.
-      - name: "nested-structs"
-        disabled: true
-
-      # This doesn't make sense with 1.22 loop var changes.
-      - name: "range-val-address"
-        disabled: true
-
-      # This flags things that do not seem like a problem, e.g. "sixHours".
-      - name: "time-naming"
-        disabled: true
-
-      # This causes a ton of failures. Many are fairly safe. It might be nice to
-      # enable, but probably not worth the effort.
-      - name: "unchecked-type-assertion"
-        disabled: true
-
-      # This seems to give many false positives.
-      - name: "unconditional-recursion"
-        disabled: true
-
-      # This is covered elsewhere and we want to ignore some
-      # functions such as fmt.Fprintf.
-      - name: "unhandled-error"
-        disabled: true
-
-      # We generally have unused receivers in tests for meeting the
-      # requirements of an interface.
-      - name: "unused-receiver"
-        disabled: true
-
-  tagliatelle:
-    case:
+  settings:
+    # Please note that we only use depguard for blocking packages and
+    # gomodguard for blocking modules.
+    depguard:
       rules:
-        avro: "snake"
-        bson: "snake"
-        env: "upperSnake"
-        envconfig: "upperSnake"
-        json: "snake"
-        mapstructure: "snake"
-        xml: "snake"
-        yaml: "snake"
+        main:
+          deny:
+            - pkg: github.com/likexian/gokit/assert
+              desc: Use github.com/stretchr/testify/assert
+            - pkg: golang.org/x/exp/maps
+              desc: Use maps instead.
+            - pkg: golang.org/x/exp/slices
+              desc: Use slices instead.
+            - pkg: golang.org/x/exp/slog
+              desc: Use log/slog instead.
+            - pkg: google.golang.org/api/compute/v1
+              desc: Use cloud.google.com/go/compute/apiv1 instead.
+            - pkg: google.golang.org/api/cloudresourcemanager/v1
+              desc: Use cloud.google.com/go/resourcemanager/apiv3 instead.
+            - pkg: google.golang.org/api/serviceusage/v1
+              desc: Use cloud.google.com/go/serviceusage/apiv1 instead.
+            - pkg: io/ioutil
+              desc: Deprecated. Functions have been moved elsewhere.
+            - pkg: k8s.io/utils/strings/slices
+              desc: Use slices
+            - pkg: math/rand$
+              desc: Use math/rand/v2 or crypto/rand as appropriate.
+            - pkg: sort
+              desc: Use slices instead
 
-  unparam:
-    check-exported: true
+    errcheck:
+      # Don't allow setting of error to the blank identifier. If there is a legitimate
+      # reason, there should be a nolint with an explanation.
+      check-blank: true
+      exclude-functions:
+        # If we are rolling back a transaction, we are often already in an error
+        # state.
+        - (*database/sql.Tx).Rollback
 
-  wrapcheck:
-    ignoreSigs:
-      - ".Errorf("
-      - "errgroup.NewMultiError("
-      - "errors.Join("
-      - "errors.New("
-      - ".Wait("
-      - ".WithStack("
-      - ".Wrap("
-      - ".Wrapf("
-      - "v5.Retry[T any]("
+        # It is reasonable to ignore errors if Cleanup fails in most cases.
+        - (*github.com/google/renameio/v2.PendingFile).Cleanup
 
-issues:
-  exclude-use-default: false
+        # We often do not care if unlocking failed as we are exiting anyway.
+        - (*github.com/gofrs/flock.Flock).Unlock
 
-  exclude-dirs:
-    - "geoip-build/mmcsv"
+        # We often don't care if removing a file failed (e.g., it doesn't exist)
+        - os.Remove
+        - os.RemoveAll
 
-  exclude-files:
-    - "_easyjson\\.go$"
-    - "_easyjson_test\\.go$"
-    - "_xgb2code\\.go$"
-    - "_json2vector\\.go$"
+    errchkjson:
+      report-no-exported: true
 
-  exclude-rules:
-    - linters:
-        - "bodyclose"
+    errorlint:
+      errorf: true
+      asserts: true
+      comparison: true
+
+    exhaustive:
+      default-signifies-exhaustive: true
+
+    forbidigo:
+      # Forbid the following identifiers
+      forbid:
+        - pattern: ^atomic.Value$
+          pkg: ^sync/atomic$
+          msg: Use atomic.Pointer instead.
+        - pattern: GeoFeed
+          msg: you should use the `Geofeed` qualifier instead
+        - pattern: Geoip
+          msg: you should use the `GeoIP` qualifier instead
+        - pattern: geoIP
+          msg: you should use the `geoip` qualifier instead
+        - pattern: ^hubSpot
+          msg: you should use the `hubspot` qualifier instead
+        - pattern: Maxmind
+          msg: you should use the `MaxMind` qualifier instead
+        - pattern: ^maxMind
+          msg: you should use the `maxmind` qualifier instead
+        - pattern: Minfraud
+          msg: you should use the `MinFraud` qualifier instead
+        - pattern: ^minFraud
+          msg: you should use the `minfraud` qualifier instead
+        - pattern: "[Uu]ser[iI][dD]"
+          msg: you should use the `accountID` or the `AccountID` qualifier instead
+        - pattern: WithEnterpriseURLs
+          msg: Use ghe.NewClient instead.
+        - pattern: ^bigquery.NewClient
+          msg: you should use mmgcloud.NewBigQueryClient instead.
+        - pattern: ^drive.NewService
+          msg: you should use mmgdrive.NewGDrive instead.
+        - pattern: ^filepath.Walk$
+          msg: you should use filepath.WalkDir instead as it doesn't call os.Lstat on every entry.
+        - pattern: ^math.Min$
+          msg: you should use the min built-in instead.
+        - pattern: ^mux.Vars$
+          msg: use req.PathValue instead.
+        - pattern: ^net.ParseCIDR
+          msg: you should use netip.ParsePrefix unless you really need a *net.IPNet
+        - pattern: ^net.ParseIP
+          msg: you should use netip.ParseAddr unless you really need a net.IP
+        - pattern: ^pgtype.NewMap
+          msg: you should use mmdatabase.NewTypeMap instead
+        - pattern: ^sheets.NewService
+          msg: you should use mmgcloud.NewSheetsService instead.
+        - pattern: ^storage.NewClient
+          msg: you should use gstorage.NewClient instead. This sets the HTTP client settings that we need for internal use.
+        - pattern: ^os.IsNotExist
+          msg: As per their docs, new code should use errors.Is(err, fs.ErrNotExist).
+        - pattern: ^os.IsExist
+          msg: As per their docs, new code should use errors.Is(err, fs.ErrExist)
+        - pattern: ^net.LookupIP
+          msg: You should use net.Resolver functions instead.
+        - pattern: ^net.LookupCNAME
+          msg: You should use net.Resolver functions instead.
+        - pattern: ^net.LookupHost
+          msg: You should use net.Resolver functions instead.
+        - pattern: ^net.LookupPort
+          msg: You should use net.Resolver functions instead.
+        - pattern: ^net.LookupTXT
+          msg: You should use net.Resolver functions instead.
+        - pattern: ^net.LookupAddr
+          msg: You should use net.Resolver functions instead.
+        - pattern: ^net.LookupMX
+          msg: You should use net.Resolver functions instead.
+        - pattern: ^net.LookupNS
+          msg: You should use net.Resolver functions instead.
+        - pattern: ^net.LookupSRV
+          msg: You should use net.Resolver functions instead.
+
+    gocritic:
+      enable-all: true
+      disabled-checks:
+        # Revive's defer rule already captures this. This caught no extra cases.
+        - deferInLoop
+
+        # Given that all of our code runs on Linux and the / separate should
+        # work fine, this seems less important.
+        - filepathJoin
+
+        # This might be good, but we would have to revisit a lot of code.
+        - hugeParam
+
+        # This might be good, but I don't think we want to encourage
+        # significant changes to regexes as we port stuff from Perl.
+        - regexpSimplify
+
+        # This seems like it might also be good, but a lot of existing code
+        # fails.
+        - sloppyReassign
+
+        # I am not sure we would want this linter and a lot of existing
+        # code fails.
+        - unnamedResult
+
+        # Covered by nolintlint
+        - whyNoLint
+
+    gomoddirectives:
+      replace-allow-list:
+        # We want to use an old version due to race conditions in the latest
+        # release.
+        - github.com/fsnotify/fsnotify
+        # We want to use an old version due to a logging issue.
+        - github.com/snowflakedb/gosnowflake
+      toolchain-forbidden: true
+      go-version-pattern: \d\.\d+(\.0)?
+
+    # IMPORTANT: gomodguard blocks _modules_, not arbitrary packages. Be
+    # sure to use the module path from the go.mod file for these.
+    # See https://github.com/ryancurrah/gomodguard/issues/12
+    gomodguard:
+      blocked:
+        modules:
+          - github.com/avct/uasurfer:
+              recommendations:
+                - github.com/xavivars/uasurfer
+              reason: The original avct module appears abandoned.
+          - github.com/BurntSushi/toml:
+              recommendations:
+                - github.com/pelletier/go-toml/v2
+              reason: This library panics frequently on invalid input.
+          - github.com/pelletier/go-toml:
+              recommendations:
+                - github.com/pelletier/go-toml/v2
+              reason: This is an outdated version.
+          - github.com/gofrs/uuid:
+              recommendations:
+                - github.com/google/uuid
+          - github.com/gofrs/uuid/v5:
+              recommendations:
+                - github.com/google/uuid
+          - github.com/satori/go.uuid:
+              recommendations:
+                - github.com/google/uuid
+          - github.com/google/uuid:
+              recommendations:
+                - github.com/google/uuid
+          - github.com/lib/pq:
+              recommendations:
+                - github.com/jackc/pgx
+              reason: This library is no longer actively maintained.
+          - github.com/neilotoole/errgroup:
+              recommendations:
+                - golang.org/x/sync/errgroup
+              reason: This library can lead to subtle deadlocks in certain use cases.
+          - github.com/pariz/gountries:
+              reason: This library's data is not actively maintained. Use GeoInfo data.
+            github.com/pkg/errors:
+              recommendations:
+                - errors
+              reason: pkg/errors is no longer maintained.
+          - github.com/RackSec/srslog:
+              recommendations:
+                - log/syslog
+              reason: This library's data is not actively maintained.
+          - github.com/ua-parser/uap-go:
+              recommendations:
+                - github.com/xavivars/uasurfer
+              reason: The performance of this library is absolutely abysmal.
+          - github.com/ugorji/go:
+              recommendations:
+                - encoding/json
+                - github.com/mailru/easyjson
+              reason: This library is poorly maintained. We should default to using encoding/json and use easyjson where performance really matters.
+          - github.com/zeebo/assert:
+              recommendations:
+                - github.com/stretchr/testify/assert
+              reason: Use github.com/stretchr/testify/assert
+          - gopkg.in/yaml.v2:
+              recommendations:
+                - github.com/goccy/go-yaml
+              reason: Not actively maintained.
+          - gopkg.in/yaml.v3:
+              recommendations:
+                - github.com/goccy/go-yaml
+              reason: Not actively maintained.
+          - gotest.tools/v3:
+              recommendations:
+                - github.com/stretchr/testify/assert
+              reason: Use github.com/stretchr/testify/assert
+          - inet.af/netaddr:
+              recommendations:
+                - net/netip
+                - go4.org/netipx
+              reason: inet.af/netaddr has been deprecated.
+        versions:
+          - github.com/jackc/pgconn:
+              reason: Use github.com/jackc/pgx/v5
+          - github.com/jackc/pgtype:
+              reason: Use github.com/jackc/pgx/v5
+          - github.com/jackc/pgx:
+              version: < 5.0.0
+              reason: Use github.com/jackc/pgx/v5
+
+    gosec:
+      excludes:
+        # G104 - "Audit errors not checked." We use errcheck for this.
+        - G104
+
+        # G306 - "Expect WriteFile permissions to be 0600 or less".
+        - G306
+
+        # Prohibits defer (*os.File).Close, which we allow when reading from file.
+        - G307
+
+        # We use md5 in geoipupdate
+        - G401
+        - G501
+
+        # no longer relevant with 1.22
+        - G601
+
+    govet:
+      disable:
+        # Although it is very useful in particular cases where we are trying to
+        # use as little memory as possible, there are even more cases where
+        # other organizations may make more sense.
+        - fieldalignment
+      enable-all: true
+      settings:
+        shadow:
+          strict: true
+
+    loggercheck:
+      # although it seems like this should remove the need for our custom
+      # Ruleguard check, it misses things that seems to catch. However, it
+      # is possible that this will catch things that misses as that check
+      # is very simple.
+      no-printf-like: true
+
+    misspell:
+      locale: US
+      extra-words:
+        - typo: marshall
+          correction: marshal
+        - typo: marshalling
+          correction: marshaling
+        - typo: marshalls
+          correction: marshals
+        - typo: unmarshall
+          correction: unmarshal
+        - typo: unmarshalling
+          correction: unmarshaling
+        - typo: unmarshalls
+          correction: unmarshals
+
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+      allow-no-explanation:
+        - misspell
+      # Setting allow-unused to false would be nice. We previously had it that
+      # way. However there is an unresolved issue where it occasionally fails
+      # when it should not. We think there might be some kind of caching bug in
+      # golangci-lint. See
+      # https://maxmind.slack.com/archives/C07ER81BQ4T/p1739389216305519.
+      allow-unused: false
+
+    revive:
+      severity: warning
+      enable-all-rules: true
+      rules:
+        # This might be nice but it is so common that it is hard
+        # to enable.
+        - name: add-constant
+          disabled: true
+
+        - name: argument-limit
+          disabled: true
+
+        - name: cognitive-complexity
+          disabled: true
+
+        - name: comment-spacings
+          arguments:
+            - easyjson
+            - nolint
+          disabled: false
+
+        # Probably a good rule, but we have a lot of names that
+        # only have case differences.
+        - name: confusing-naming
+          disabled: true
+
+        - name: cyclomatic
+          disabled: true
+
+        # Although being consistent might be nice, I don't know that it
+        # is worth the effort enabling this rule. It doesn't have an
+        # autofix option.
+        - name: enforce-repeated-arg-type-style
+          arguments:
+            - short
+          disabled: true
+
+        - name: enforce-map-style
+          arguments:
+            - literal
+          disabled: false
+
+        # We have very few of these as we force nil slices in most places,
+        # but there are a couple of cases.
+        - name: enforce-slice-style
+          arguments:
+            - literal
+          disabled: false
+
+        - name: file-header
+          disabled: true
+
+        # We have a lot of flag parameters. This linter probably makes
+        # a good point, but we would need some cleanup or a lot of nolints.
+        - name: flag-parameter
+          disabled: true
+
+        - name: function-length
+          disabled: true
+
+        - name: function-result-limit
+          disabled: true
+
+        - name: line-length-limit
+          disabled: true
+
+        - name: max-public-structs
+          disabled: true
+
+        # We frequently use nested structs, particularly in tests.
+        - name: nested-structs
+          disabled: true
+
+        # This doesn't make sense with 1.22 loop var changes.
+        - name: range-val-address
+          disabled: true
+
+        # This flags things that do not seem like a problem, e.g. "sixHours".
+        - name: time-naming
+          disabled: true
+
+        # This causes a ton of failures. Many are fairly safe. It might be nice to
+        # enable, but probably not worth the effort.
+        - name: unchecked-type-assertion
+          disabled: true
+
+        # This seems to give many false positives.
+        - name: unconditional-recursion
+          disabled: true
+
+        # This is covered elsewhere and we want to ignore some
+        # functions such as fmt.Fprintf.
+        - name: unhandled-error
+          disabled: true
+
+        # We generally have unused receivers in tests for meeting the
+        # requirements of an interface.
+        - name: unused-receiver
+          disabled: true
+
+    sloglint:
+      # Enforce not mixing key-value pairs and attributes.
+      no-mixed-args: true
+
+      # Enforce not using global loggers.
+      no-global: all
+
+      # Enforce a snake case for keys.
+      key-naming-case: snake
+
+      # Make sure we don't use reserved keys.
+      forbidden-keys:
+        # These are included by our handler.
+        - time
+        - level
+        - logged_from
+        - message
+
+        # We don't use these two, but they are slog defaults. It would
+        # be better to avoid using them to reduce confusion and to make
+        # it easier to potentially use the defaults in the future.
+        - msg
+        - source
+
+    staticcheck:
+      checks:
+        - all
+
+        # SA1019: Using a deprecated function, variable, constant or field
+        #
+        # This is disabled as it interacts poorly with golangci-lint's caching.
+        # I believe https://github.com/golangci/golangci-lint-action/issues/420
+        # is the same underlying issue.
+        - -SA1019
+
+        # SA5008: unknown JSON option "intern" - easyjson specific option.
+        - -SA5008
+
+    tagliatelle:
+      case:
+        rules:
+          avro: snake
+          bson: snake
+          env: upperSnake
+          envconfig: upperSnake
+          json: snake
+          mapstructure: snake
+          xml: snake
+          yaml: snake
+
+    testifylint:
+      enable-all: true
+
+    unparam:
+      check-exported: true
+
+    usestdlibvars:
+      time-layout: true
+
+    usetesting:
+      os-temp-dir: true
+
+    wrapcheck:
+      ignore-sigs:
+        - .Errorf(
+        - errgroup.NewMultiError(
+        - errors.Join(
+        - errors.New(
+        - .Wait(
+        - .WithStack(
+        - .Wrap(
+        - .Wrapf(
+        - v5.Retry[T any](
+
+  exclusions:
+    generated: lax
+    rules:
       # This rule doesn't really make sense for tests where we don't have an open
       # connection and we might be passing around the response for other reasons.
-      path: "_test.go"
+      - linters:
+          - bodyclose
+        path: _test.go
 
-    - linters:
-        - "errcheck"
       # There are many cases where we want to just close resources and ignore the
       # error (e.g., for defer f.Close on a read). errcheck removed its built-in
       # wildcard ignore. I tried listing all of the cases, but it was too many
       # and some were very specific.
-      source: "\\.Close"
+      - linters:
+          - errcheck
+        source: \.Close
 
-    - linters:
-        - "forbidigo"
       # This refers to a minFraud field, not the MaxMind Account ID
-      source: "AccountUserID|Account\\.UserID"
+      - linters:
+          - forbidigo
+        source: "[Aa]ccountUserID|Account\\.UserID"
 
-    # we include both a source and text exclusion as the source exclusion
-    # misses matches where forbidigo reports the error on the first line
-    # of a chunk of a function call even though the use is on a later line.
-    - linters:
-        - "forbidigo"
-      text: "AccountUserID|Account\\.UserID"
+      # we include both a source and text exclusion as the source exclusion
+      # misses matches where forbidigo reports the error on the first line
+      # of a chunk of a function call even though the use is on a later line.
+      - linters:
+          - forbidigo
+        text: "[Aa]ccountUserID|Account\\.UserID"
 
-    - linters:
-        - "gocritic"
       # For some reason the imports stuff in ruleguard doesn't work in golangci-lint.
       # Perhaps it has an outdated version or something
-      path: "_test.go"
-      text: "ruleguard: Prefer the alternative Context method instead"
+      - linters:
+          - gocritic
+        path: _test.go
+        text: "ruleguard: Prefer the alternative Context method instead"
 
-    - linters:
-        - "gocritic"
       # The nolintlint linter behaves oddly with ruleguard rules
-      source: "// *no-ruleguard"
+      - linters:
+          - gocritic
+        source: // *no-ruleguard
 
-    - linters:
-        - "nolintlint"
       # The contextcheck linter also uses "nolint" in a slightly different way,
       # leading to falso positives from nolintlint.
-      source: "//nolint:contextcheck //.*"
+      - linters:
+          - nolintlint
+        source: //nolint:contextcheck //.*
 
-    - linters:
-        - "govet"
       # These are usually fine to shadow and not allowing shadowing for them can
       # make the code unnecessarily verbose.
-      text: 'shadow: declaration of "(ctx|err|ok)" shadows declaration'
+      - linters:
+          - govet
+        text: 'shadow: declaration of "(ctx|err|ok)" shadows declaration'
 
-    - linters:
-        - "contextcheck"
-        # With recent changes to the linter, there were a lot of failures in
-        # the tests and it wasn't clear to me that fixing them would actually
-        # improve the readability.
-        - "goconst"
-        - "nilerr"
-        - "wrapcheck"
-      path: "_test.go"
+      - linters:
+          - contextcheck
+          # With recent changes to the linter, there were a lot of failures in
+          # the tests and it wasn't clear to me that fixing them would actually
+          # improve the readability.
+          - goconst
+          - nilerr
+          - wrapcheck
+        path: _test.go
 
-    - linters:
-        - "stylecheck"
       # ST1016 - methods on the same type should have the same receiver name.
       #    easyjson doesn't interact well with this.
-      text: "ST1016"
+      - linters:
+          - staticcheck
+        text: ST1016
 
-    - linters:
-        - "wrapcheck"
-      text: "github.com/maxmind/geoipupdate/v7"
+      - linters:
+          - wrapcheck
+        text: github.com/maxmind/geoipupdate
 
-    - linters:
-        - "wrapcheck"
-      path: "_easyjson.go"
+      - linters:
+          - wrapcheck
+        path: _easyjson.go
 
-    - linters:
-        - "gocritic"
-      source: "Chmod|WriteFile"
-      text: "octalLiteral"
+      - linters:
+          - gocritic
+        text: octalLiteral
+        source: Chmod|WriteFile
+
+    paths:
+      - _easyjson\.go$
+      - _easyjson_test\.go$
+      - _xgb2code\.go$
+      - _json2vector\.go$
+      - geoip-build/mmcsv
+
+formatters:
+  enable:
+    - gci
+    - gofumpt
+    - goimports
+    - golines
+
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/maxmind/geoipupdate)
+
+    gofumpt:
+      module-path: github.com/maxmind/geoipupdate
+      extra-rules: true
+
+    goimports:
+      local-prefixes:
+        - github.com/maxmind/geoipupdate
+
+    golines:
+      shorten-comments: true
+
+  exclusions:
+    generated: lax
+    paths:
+      - _easyjson\.go$
+      - _easyjson_test\.go$
+      - _xgb2code\.go$
+      - _json2vector\.go$
+      - geoip-build/mmcsv

--- a/client/download.go
+++ b/client/download.go
@@ -109,7 +109,7 @@ func (c *Client) download(
 	escapedEdition := url.PathEscape(editionID)
 	requestURL := fmt.Sprintf(downloadEndpoint, c.endpoint, escapedEdition) + params.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, http.NoBody)
 	if err != nil {
 		return nil, time.Time{}, fmt.Errorf("creating download request: %w", err)
 	}

--- a/client/download_test.go
+++ b/client/download_test.go
@@ -24,7 +24,7 @@ func TestDownload(t *testing.T) {
 	}
 	dbContent := "edition-1 content"
 
-	lastModified, err := time.ParseInLocation("2006-01-02", "2024-02-23", time.UTC)
+	lastModified, err := time.ParseInLocation(time.DateOnly, "2024-02-23", time.UTC)
 	require.NoError(t, err)
 
 	metadataHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/client/download_test.go
+++ b/client/download_test.go
@@ -84,14 +84,16 @@ func TestDownload(t *testing.T) {
 					assert.NoError(t, err)
 				})
 
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if strings.HasPrefix(r.URL.Path, "/geoip/updates/metadata") {
-						metadataHandler.ServeHTTP(w, r)
-						return
-					}
+				server := httptest.NewServer(
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if strings.HasPrefix(r.URL.Path, "/geoip/updates/metadata") {
+							metadataHandler.ServeHTTP(w, r)
+							return
+						}
 
-					downloadHandler.ServeHTTP(w, r)
-				}))
+						downloadHandler.ServeHTTP(w, r)
+					}),
+				)
 
 				return server
 			},
@@ -108,14 +110,16 @@ func TestDownload(t *testing.T) {
 			description:      "server error",
 			preserveFileTime: false,
 			server: func(_ *testing.T) *httptest.Server {
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if strings.HasPrefix(r.URL.Path, "/geoip/updates/metadata") {
-						metadataHandler.ServeHTTP(w, r)
-						return
-					}
+				server := httptest.NewServer(
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if strings.HasPrefix(r.URL.Path, "/geoip/updates/metadata") {
+							metadataHandler.ServeHTTP(w, r)
+							return
+						}
 
-					w.WriteHeader(http.StatusInternalServerError)
-				}))
+						w.WriteHeader(http.StatusInternalServerError)
+					}),
+				)
 				return server
 			},
 			checkResult: func(t *testing.T, _ DownloadResponse, err error) {
@@ -127,18 +131,20 @@ func TestDownload(t *testing.T) {
 			description:      "wrong file format",
 			preserveFileTime: false,
 			server: func(t *testing.T) *httptest.Server {
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if strings.HasPrefix(r.URL.Path, "/geoip/updates/metadata") {
-						metadataHandler.ServeHTTP(w, r)
-						return
-					}
+				server := httptest.NewServer(
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if strings.HasPrefix(r.URL.Path, "/geoip/updates/metadata") {
+							metadataHandler.ServeHTTP(w, r)
+							return
+						}
 
-					jsonData := `{"message": "Hello, world!", "status": "ok"}`
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(http.StatusOK)
-					_, err := w.Write([]byte(jsonData))
-					assert.NoError(t, err)
-				}))
+						jsonData := `{"message": "Hello, world!", "status": "ok"}`
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						_, err := w.Write([]byte(jsonData))
+						assert.NoError(t, err)
+					}),
+				)
 				return server
 			},
 			checkResult: func(t *testing.T, _ DownloadResponse, err error) {
@@ -167,14 +173,16 @@ func TestDownload(t *testing.T) {
 					assert.NoError(t, err)
 				})
 
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if strings.HasPrefix(r.URL.Path, "/geoip/updates/metadata") {
-						metadataHandler.ServeHTTP(w, r)
-						return
-					}
+				server := httptest.NewServer(
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if strings.HasPrefix(r.URL.Path, "/geoip/updates/metadata") {
+							metadataHandler.ServeHTTP(w, r)
+							return
+						}
 
-					downloadHandler.ServeHTTP(w, r)
-				}))
+						downloadHandler.ServeHTTP(w, r)
+					}),
+				)
 
 				return server
 			},
@@ -219,14 +227,16 @@ func TestDownload(t *testing.T) {
 					assert.NoError(t, err)
 				})
 
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if strings.HasPrefix(r.URL.Path, "/geoip/updates/metadata") {
-						metadataHandler.ServeHTTP(w, r)
-						return
-					}
+				server := httptest.NewServer(
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if strings.HasPrefix(r.URL.Path, "/geoip/updates/metadata") {
+							metadataHandler.ServeHTTP(w, r)
+							return
+						}
 
-					downloadHandler.ServeHTTP(w, r)
-				}))
+						downloadHandler.ServeHTTP(w, r)
+					}),
+				)
 
 				return server
 			},

--- a/client/metadata.go
+++ b/client/metadata.go
@@ -31,7 +31,7 @@ func (c *Client) getMetadata(
 
 	metadataRequestURL := fmt.Sprintf(metadataEndpoint, c.endpoint) + params.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataRequestURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataRequestURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating metadata request: %w", err)
 	}

--- a/client/metadata_test.go
+++ b/client/metadata_test.go
@@ -22,19 +22,21 @@ func TestGetMetadata(t *testing.T) {
 			description:      "successful request",
 			preserveFileTime: false,
 			server: func(t *testing.T) *httptest.Server {
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					jsonData := `
+				server := httptest.NewServer(
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						jsonData := `
 {
     "databases": [
         { "edition_id": "edition-1", "md5": "123456", "date": "2024-02-23" }
     ]
 }
 `
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(http.StatusOK)
-					_, err := w.Write([]byte(jsonData))
-					assert.NoError(t, err)
-				}))
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						_, err := w.Write([]byte(jsonData))
+						assert.NoError(t, err)
+					}),
+				)
 				return server
 			},
 			checkResult: func(t *testing.T, receivedMetadata *metadata, err error) {
@@ -50,9 +52,11 @@ func TestGetMetadata(t *testing.T) {
 			description:      "server error",
 			preserveFileTime: false,
 			server: func(_ *testing.T) *httptest.Server {
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusInternalServerError)
-				}))
+				server := httptest.NewServer(
+					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusInternalServerError)
+					}),
+				)
 				return server
 			},
 			checkResult: func(t *testing.T, receivedMetadata *metadata, err error) {

--- a/cmd/geoipupdate/end_to_end_test.go
+++ b/cmd/geoipupdate/end_to_end_test.go
@@ -36,7 +36,7 @@ func TestUpdater(t *testing.T) {
 	err = os.WriteFile(dbFile, []byte("old edition-2 content"), os.ModePerm)
 	require.NoError(t, err)
 
-	lastModified, err := time.ParseInLocation("2006-01-02", "2024-02-23", time.UTC)
+	lastModified, err := time.ParseInLocation(time.DateOnly, "2024-02-23", time.UTC)
 	require.NoError(t, err)
 
 	// mock metadata handler.
@@ -155,7 +155,6 @@ func TestUpdater(t *testing.T) {
 	w.Close()
 	out, err := io.ReadAll(r)
 	require.NoError(t, err)
-	//nolint:lll
 	expectedOutput := `\[{"edition_id":"edition\-1","old_hash":"618dd27a10de24809ec160d6807f363f","new_hash":"618dd27a10de24809ec160d6807f363f","checked_at":\d+},{"edition_id":"edition\-2","old_hash":"2242f06b3b2d147987b67017cb7a5ab8","new_hash":"c9bbf7cb507370339633b44001bae038","modified_at":1708646400,"checked_at":\d+}]`
 	require.Regexp(t, expectedOutput, string(out))
 

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/maxmind/geoipupdate/v7
 
 go 1.23.0
 
-toolchain go1.24.1
-
 require (
 	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/gofrs/flock v0.12.1

--- a/internal/geoipupdate/config.go
+++ b/internal/geoipupdate/config.go
@@ -404,7 +404,8 @@ func validateConfig(config *Config) error {
 	// and many people still use this combination. With a real account id
 	// and license key now being required, we want to give those people a
 	// sensible error message.
-	if (config.AccountID == 0 || config.AccountID == 999999) && config.LicenseKey == "000000000000" {
+	if (config.AccountID == 0 || config.AccountID == 999999) &&
+		config.LicenseKey == "000000000000" {
 		return errors.New("geoipupdate requires a valid AccountID and LicenseKey combination")
 	}
 

--- a/internal/geoipupdate/config_test.go
+++ b/internal/geoipupdate/config_test.go
@@ -82,10 +82,12 @@ EditionIDs GeoLite2-Country GeoLite2-City
 				LicenseKey:        "000000000001",
 				DatabaseDirectory: filepath.Clean(vars.DefaultDatabaseDirectory),
 				EditionIDs:        []string{"GeoLite2-Country", "GeoLite2-City"},
-				LockFile:          filepath.Clean(filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock")),
-				URL:               "https://updates.maxmind.com",
-				RetryFor:          5 * time.Minute,
-				Parallelism:       1,
+				LockFile: filepath.Clean(
+					filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock"),
+				),
+				URL:         "https://updates.maxmind.com",
+				RetryFor:    5 * time.Minute,
+				Parallelism: 1,
 			},
 		},
 		{
@@ -135,10 +137,12 @@ ProductIds GeoLite2-Country GeoLite2-City
 				LicenseKey:        "000000000001",
 				DatabaseDirectory: filepath.Clean(vars.DefaultDatabaseDirectory),
 				EditionIDs:        []string{"GeoLite2-Country", "GeoLite2-City"},
-				LockFile:          filepath.Clean(filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock")),
-				URL:               "https://updates.maxmind.com",
-				RetryFor:          5 * time.Minute,
-				Parallelism:       1,
+				LockFile: filepath.Clean(
+					filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock"),
+				),
+				URL:         "https://updates.maxmind.com",
+				RetryFor:    5 * time.Minute,
+				Parallelism: 1,
 			},
 		},
 		{
@@ -319,10 +323,12 @@ Parallelism 2`,
 				DatabaseDirectory: filepath.Clean(vars.DefaultDatabaseDirectory),
 				EditionIDs:        []string{"GeoIP2-City"},
 				LicenseKey:        "abcd",
-				LockFile:          filepath.Clean(filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock")),
-				URL:               "https://updates.maxmind.com",
-				RetryFor:          5 * time.Minute,
-				Parallelism:       4,
+				LockFile: filepath.Clean(
+					filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock"),
+				),
+				URL:         "https://updates.maxmind.com",
+				RetryFor:    5 * time.Minute,
+				Parallelism: 4,
 			},
 		},
 		{
@@ -352,10 +358,12 @@ EditionIDs GeoIP2-City`,
 				DatabaseDirectory: filepath.Clean(vars.DefaultDatabaseDirectory),
 				EditionIDs:        []string{"GeoIP2-City"},
 				LicenseKey:        "abcd",
-				LockFile:          filepath.Clean(filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock")),
-				URL:               "https://updates.maxmind.com",
-				RetryFor:          5 * time.Minute,
-				Parallelism:       1,
+				LockFile: filepath.Clean(
+					filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock"),
+				),
+				URL:         "https://updates.maxmind.com",
+				RetryFor:    5 * time.Minute,
+				Parallelism: 1,
 			},
 		},
 		{
@@ -372,10 +380,12 @@ SkipPeerVerification 1
 				DatabaseDirectory: filepath.Clean(vars.DefaultDatabaseDirectory),
 				EditionIDs:        []string{"GeoIP2-City"},
 				LicenseKey:        "abcd",
-				LockFile:          filepath.Clean(filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock")),
-				URL:               "https://updates.maxmind.com",
-				RetryFor:          5 * time.Minute,
-				Parallelism:       1,
+				LockFile: filepath.Clean(
+					filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock"),
+				),
+				URL:         "https://updates.maxmind.com",
+				RetryFor:    5 * time.Minute,
+				Parallelism: 1,
 			},
 		},
 		{
@@ -386,10 +396,12 @@ SkipPeerVerification 1
 				DatabaseDirectory: filepath.Clean(vars.DefaultDatabaseDirectory),
 				EditionIDs:        []string{"GeoIP2-City"},
 				LicenseKey:        "123",
-				LockFile:          filepath.Clean(filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock")),
-				URL:               "https://updates.maxmind.com",
-				RetryFor:          5 * time.Minute,
-				Parallelism:       1,
+				LockFile: filepath.Clean(
+					filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock"),
+				),
+				URL:         "https://updates.maxmind.com",
+				RetryFor:    5 * time.Minute,
+				Parallelism: 1,
 			},
 		},
 		{
@@ -408,10 +420,12 @@ EditionIDs    GeoLite2-City      GeoLite2-Country
 				DatabaseDirectory: filepath.Clean(vars.DefaultDatabaseDirectory),
 				EditionIDs:        []string{"GeoLite2-City", "GeoLite2-Country"},
 				LicenseKey:        "456",
-				LockFile:          filepath.Clean(filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock")),
-				URL:               "https://updates.maxmind.com",
-				RetryFor:          5 * time.Minute,
-				Parallelism:       1,
+				LockFile: filepath.Clean(
+					filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock"),
+				),
+				URL:         "https://updates.maxmind.com",
+				RetryFor:    5 * time.Minute,
+				Parallelism: 1,
 			},
 		},
 		{
@@ -423,10 +437,12 @@ EditionIDs    GeoLite2-City      GeoLite2-Country
 				DatabaseDirectory: filepath.Clean(vars.DefaultDatabaseDirectory),
 				EditionIDs:        []string{"GeoLite2-City", "GeoLite2-Country"},
 				LicenseKey:        "456",
-				LockFile:          filepath.Clean(filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock")),
-				URL:               "https://updates.maxmind.com",
-				RetryFor:          5 * time.Minute,
-				Parallelism:       1,
+				LockFile: filepath.Clean(
+					filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock"),
+				),
+				URL:         "https://updates.maxmind.com",
+				RetryFor:    5 * time.Minute,
+				Parallelism: 1,
 			},
 		},
 		{
@@ -472,10 +488,12 @@ EditionIDs    GeoLite2-City      GeoLite2-Country
 				DatabaseDirectory: filepath.Clean(vars.DefaultDatabaseDirectory),
 				EditionIDs:        []string{"GeoIP2-City"},
 				LicenseKey:        "456",
-				LockFile:          filepath.Clean(filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock")),
-				RetryFor:          5 * time.Minute,
-				Parallelism:       1,
-				URL:               "http://test",
+				LockFile: filepath.Clean(
+					filepath.Join(vars.DefaultDatabaseDirectory, ".geoipupdate.lock"),
+				),
+				RetryFor:    5 * time.Minute,
+				Parallelism: 1,
+				URL:         "http://test",
 			},
 		},
 	}
@@ -762,11 +780,17 @@ func TestSetConfigFromEnv(t *testing.T) {
 			licenseKeyFile := test.Env["GEOIPUPDATE_LICENSE_KEY_FILE"]
 
 			if test.AccountIDFileContents != "" {
-				require.NoError(t, os.WriteFile(accountIDFile, []byte(test.AccountIDFileContents), 0o600))
+				require.NoError(
+					t,
+					os.WriteFile(accountIDFile, []byte(test.AccountIDFileContents), 0o600),
+				)
 			}
 
 			if test.LicenseKeyFileContents != "" {
-				require.NoError(t, os.WriteFile(licenseKeyFile, []byte(test.LicenseKeyFileContents), 0o600))
+				require.NoError(
+					t,
+					os.WriteFile(licenseKeyFile, []byte(test.LicenseKeyFileContents), 0o600),
+				)
 			}
 
 			withEnvVars(t, test.Env, func() {

--- a/internal/geoipupdate/database/local_file_writer.go
+++ b/internal/geoipupdate/database/local_file_writer.go
@@ -205,7 +205,11 @@ func (w *fileWriter) write(r io.Reader) error {
 func (w *fileWriter) validateHash(h string) error {
 	tempFileHash := byteToString(w.md5Writer.Sum(nil))
 	if !strings.EqualFold(h, tempFileHash) {
-		return fmt.Errorf("md5 of new database (%s) does not match expected md5 (%s)", tempFileHash, h)
+		return fmt.Errorf(
+			"md5 of new database (%s) does not match expected md5 (%s)",
+			tempFileHash,
+			h,
+		)
 	}
 	return nil
 }

--- a/internal/geoipupdate/geoip_updater_test.go
+++ b/internal/geoipupdate/geoip_updater_test.go
@@ -96,7 +96,7 @@ func TestUpdaterOutput(t *testing.T) {
 		},
 	}
 
-	require.Equal(t, len(wantDatabases), len(outputDatabases))
+	require.Len(t, outputDatabases, len(wantDatabases))
 
 	for i := range wantDatabases {
 		require.Equal(t, wantDatabases[i].EditionID, outputDatabases[i].EditionID)

--- a/internal/vars/defaults_windows.go
+++ b/internal/vars/defaults_windows.go
@@ -7,6 +7,8 @@ import (
 var (
 	// I'm not sure these make sense. However they can be overridden at runtime
 	// and in the configuration, so we have some flexibility.
-	DefaultConfigFile        = os.Getenv("SYSTEMDRIVE") + `\ProgramData\MaxMind\GeoIPUpdate\GeoIP.conf`
+	DefaultConfigFile = os.Getenv(
+		"SYSTEMDRIVE",
+	) + `\ProgramData\MaxMind\GeoIPUpdate\GeoIP.conf`
 	DefaultDatabaseDirectory = os.Getenv("SYSTEMDRIVE") + `\ProgramData\MaxMind\GeoIPUpdate\GeoIP`
 )


### PR DESCRIPTION
- **Bump golangci/golangci-lint-action from 6 to 7**
- **Sync golangci-lint config**
- **Run golangci-lint fmt**
- **golangci-lint autofixes**
- **Do not use toolchain directive**
