### PR TITLE
Apply golangci-lint fixes

### DIFF
--- a/internal/geoipupdate/database/local_file_writer_test.go
+++ b/internal/geoipupdate/database/local_file_writer_test.go
@@ -15,16 +15,14 @@ func TestLocalFileWriterWrite(t *testing.T) {
 	testTime := time.Date(2023, 4, 10, 12, 47, 31, 0, time.UTC)
 
 	tests := []struct {
-		description string
-		//nolint:revive // support older versions
+		description      string
 		checkErr         func(require.TestingT, error, ...any)
 		preserveFileTime bool
-		//nolint:revive // support older versions
-		checkTime    func(require.TestingT, any, any, ...any)
-		editionID    string
-		reader       io.ReadCloser
-		newMD5       string
-		lastModified time.Time
+		checkTime        func(require.TestingT, any, any, ...any)
+		editionID        string
+		reader           io.ReadCloser
+		newMD5           string
+		lastModified     time.Time
 	}{
 		{
 			description:      "success",

--- a/internal/geoipupdate/database/local_file_writer_test.go
+++ b/internal/geoipupdate/database/local_file_writer_test.go
@@ -17,10 +17,10 @@ func TestLocalFileWriterWrite(t *testing.T) {
 	tests := []struct {
 		description string
 		//nolint:revive // support older versions
-		checkErr         func(require.TestingT, error, ...interface{})
+		checkErr         func(require.TestingT, error, ...any)
 		preserveFileTime bool
 		//nolint:revive // support older versions
-		checkTime    func(require.TestingT, interface{}, interface{}, ...interface{})
+		checkTime    func(require.TestingT, any, any, ...any)
 		editionID    string
 		reader       io.ReadCloser
 		newMD5       string


### PR DESCRIPTION
## Summary
- Replace interface{} with any for modern Go syntax (Go 1.18+)
- Remove unused nolint directives that are no longer needed

## Test plan
- [x] golangci-lint run passes with 0 issues
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)