### PR TITLE
[docker] Use a single config file to set required parameters.

### DIFF
--- a/doc/docker.md
+++ b/doc/docker.md
@@ -7,23 +7,20 @@ The source code is available on [GitHub](https://github.com/maxmind/geoipupdate)
 
 ## Configuring
 
-The Docker image is configured by environment variables. The following
-variables are required:
+The Docker image is configured by environment variables.
 
-* `GEOIPUPDATE_EDITION_IDS` - List of space-separated database edition IDs.
-  Edition IDs may consist of letters, digits, and dashes. For example,
-  `GeoIP2-City` would download the GeoIP2 City database (`GeoIP2-City`).
+User must set `EDITION_IDS`, `ACCOUNT_ID` and `LICENSE_KEY` via one for the following methods:
 
-One of:
+1. Via [a configuration file](./GeoIP.conf.md) by setting environment variable `GEOIPUPDATE_CONF_FILE`.
 
-* `GEOIPUPDATE_ACCOUNT_ID` - Your MaxMind account ID.
-* `GEOIPUPDATE_ACCOUNT_ID_FILE` - A file containing your MaxMind account ID.
-
-One of:
-
-* `GEOIPUPDATE_LICENSE_KEY` - Your case-sensitive MaxMind license key.
-* `GEOIPUPDATE_LICENSE_KEY_FILE` - A file containing your case-sensitive
-  MaxMind license key.
+2. Via required the following required variables:
+  * `GEOIPUPDATE_EDITION_IDS` - List of space-separated database edition IDs. Edition IDs may consist of letters, digits, and dashes. For example. `GeoIP2-City` would download the GeoIP2 City database (`GeoIP2-City`).
+  * One of:
+    * `GEOIPUPDATE_ACCOUNT_ID` - Your MaxMind account ID.
+    * `GEOIPUPDATE_ACCOUNT_ID_FILE` - A file containing your MaxMind account ID.
+  * One of:
+    * `GEOIPUPDATE_LICENSE_KEY` - Your case-sensitive MaxMind license key.
+    * `GEOIPUPDATE_LICENSE_KEY_FILE` - A file containing your case-sensitive MaxMind license key.
 
 The following are optional:
 

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -19,25 +19,28 @@ log_dir="/tmp/geoipupdate"
 log_file="$log_dir/.healthcheck"
 flags="--output"
 frequency=$((GEOIPUPDATE_FREQUENCY * 60 * 60))
-export GEOIPUPDATE_CONF_FILE=""
 
 if [ -z "$GEOIPUPDATE_DB_DIR" ]; then
   export GEOIPUPDATE_DB_DIR="$database_dir"
 fi
 
-if [ -z "$GEOIPUPDATE_ACCOUNT_ID" ] && [ -z  "$GEOIPUPDATE_ACCOUNT_ID_FILE" ]; then
-    echo "ERROR: You must set the environment variable GEOIPUPDATE_ACCOUNT_ID or GEOIPUPDATE_ACCOUNT_ID_FILE!"
+if [ -z "${GEOIPUPDATE_CONF_FILE}" ]; then
+  has_error=0
+  if [ -z "$GEOIPUPDATE_ACCOUNT_ID" ] && [ -z  "$GEOIPUPDATE_ACCOUNT_ID_FILE" ]; then
+      echo "ERROR: You must set the environment variable GEOIPUPDATE_ACCOUNT_ID or GEOIPUPDATE_ACCOUNT_ID_FILE!"
+      has_error=1
+  fi
+  if [ -z "$GEOIPUPDATE_LICENSE_KEY" ] && [ -z  "$GEOIPUPDATE_LICENSE_KEY_FILE" ]; then
+      echo "ERROR: You must set the environment variable GEOIPUPDATE_LICENSE_KEY or GEOIPUPDATE_LICENSE_KEY_FILE!"
+      has_error=1
+  fi
+  if [ -z "$GEOIPUPDATE_EDITION_IDS" ]; then
+      echo "ERROR: You must set the environment variable GEOIPUPDATE_EDITION_IDS!"
+      has_error=1
+  fi
+  if [ "${has_error}" != "0" ]; then
     exit 1
-fi
-
-if [ -z "$GEOIPUPDATE_LICENSE_KEY" ] && [ -z  "$GEOIPUPDATE_LICENSE_KEY_FILE" ]; then
-    echo "ERROR: You must set the environment variable GEOIPUPDATE_LICENSE_KEY or GEOIPUPDATE_LICENSE_KEY_FILE!"
-    exit 1
-fi
-
-if [ -z "$GEOIPUPDATE_EDITION_IDS" ]; then
-    echo "ERROR: You must set the environment variable GEOIPUPDATE_EDITION_IDS!"
-    exit 1
+  fi
 fi
 
 mkdir -p $log_dir


### PR DESCRIPTION
We can put all required values in a single config file, instead of setting two files GEOIPUPDATE_ACCOUNT_ID_FILE and GEOIPUPDATE_LICENSE_KEY_FILE.