### PR TITLE
Add configuration and instructions to install via the Proto toolchain manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ default.
 
 Please see our [Docker documentation](doc/docker.md).
 
+### Installing via Proto
+
+To install with the [Proto](https://moonrepo.dev) toolchain manager, run:
+
+```shell
+$ proto plugin add geoipupdate "https://raw.githubusercontent.com/maxmind/geoipupdate/refs/heads/main/proto.yaml"
+proto install geoipupdate
+```
+
 ### Installation from source or Git
 
 You need the Go compiler (1.24+). You can get it at the [Go

--- a/proto.yaml
+++ b/proto.yaml
@@ -1,0 +1,30 @@
+# Proto plugin for the MaxMind `geoipupdate` tool
+# https://moonrepo.dev/docs/proto/non-wasm-plugin
+
+name: geoipupdate
+type: cli
+
+platform:
+  macos:
+    downloadFile: 'geoipupdate_{version}_darwin_{arch}.tar.gz'
+    archivePrefix: 'geoipupdate_{version}_darwin_{arch}'
+  windows:
+    downloadFile: 'geoipupdate_{version}_windows_{arch}.tar.gz'
+    archivePrefix: 'geoipupdate_{version}_windows_{arch}'
+  linux:
+    downloadFile: 'geoipupdate_{version}_linux_{arch}.tar.gz'
+    archivePrefix: 'geoipupdate_{version}_linux_{arch}'
+
+install:
+  downloadUrl: 'https://github.com/maxmind/geoipupdate/releases/download/v{version}/{download_file}'
+  unpack: true
+  arch:
+    aarch64: arm64
+    x86_64: amd64
+  exes:
+    geoipupdate:
+      exePath: 'geoipupdate'
+      primary: true
+
+resolve:
+  gitUrl: 'https://github.com/maxmind/geoipupdate'


### PR DESCRIPTION
The [Proto](https://moonrepo.dev/proto) toolchain manager is pretty handy for managing tools like `geoipupdate`, and I'm currently considering it adopting it in a large monorepo at my job. Adding this YAML file to the repo makes it easy to integrate the tool.

If/once this is merged, I'll send a PR to the Moonrepo folks to add this to the [Proto tool registry](https://moonrepo.dev/docs/proto/tools#third-party).