### PR TITLE
Fix gosec lints from golangci-lint v2.10.1

### DIFF
--- a/client/download.go
+++ b/client/download.go
@@ -116,7 +116,7 @@ func (c *Client) download(
 	req.Header.Add("User-Agent", "geoipupdate/"+vars.Version)
 	req.SetBasicAuth(strconv.Itoa(c.accountID), c.licenseKey)
 
-	response, err := c.httpClient.Do(req)
+	response, err := c.httpClient.Do(req) //nolint:gosec // URL is from known config
 	if err != nil {
 		return nil, time.Time{}, fmt.Errorf("performing download request: %w", err)
 	}

--- a/client/metadata.go
+++ b/client/metadata.go
@@ -38,7 +38,7 @@ func (c *Client) getMetadata(
 	req.Header.Add("User-Agent", "geoipupdate/"+vars.Version)
 	req.SetBasicAuth(strconv.Itoa(c.accountID), c.licenseKey)
 
-	response, err := c.httpClient.Do(req)
+	response, err := c.httpClient.Do(req) //nolint:gosec // URL is from known config
 	if err != nil {
 		return nil, fmt.Errorf("performing metadata request: %w", err)
 	}

--- a/cmd/geoipupdate/args.go
+++ b/cmd/geoipupdate/args.go
@@ -77,7 +77,7 @@ func getArgs() *Args {
 }
 
 func printUsage() {
-	log.Printf("Usage: %s <arguments>\n", os.Args[0])
+	log.Printf("Usage: %s <arguments>\n", os.Args[0]) //nolint:gosec // logging program name
 	flag.PrintDefaults()
 	//nolint: revive // deep exit from main package
 	os.Exit(1)

--- a/internal/geoipupdate/config.go
+++ b/internal/geoipupdate/config.go
@@ -296,7 +296,7 @@ func setConfigFromEnv(config *Config) error {
 	if value := os.Getenv("GEOIPUPDATE_ACCOUNT_ID_FILE"); value != "" {
 		var err error
 
-		accountID, err := os.ReadFile(filepath.Clean(value))
+		accountID, err := os.ReadFile(filepath.Clean(value)) //nolint:gosec // path from env var
 		if err != nil {
 			return fmt.Errorf("failed to open GEOIPUPDATE_ACCOUNT_ID_FILE: %w", err)
 		}
@@ -333,7 +333,7 @@ func setConfigFromEnv(config *Config) error {
 	if value := os.Getenv("GEOIPUPDATE_LICENSE_KEY_FILE"); value != "" {
 		var err error
 
-		licenseKey, err := os.ReadFile(filepath.Clean(value))
+		licenseKey, err := os.ReadFile(filepath.Clean(value)) //nolint:gosec // path from env var
 		if err != nil {
 			return fmt.Errorf("failed to open GEOIPUPDATE_LICENSE_KEY_FILE: %w", err)
 		}

--- a/internal/geoipupdate/config_test.go
+++ b/internal/geoipupdate/config_test.go
@@ -959,11 +959,11 @@ func TestParseProxy(t *testing.T) {
 			Proxy: "ftp://127.0.0.1:8888",
 			Err:   "unsupported proxy type: ftp",
 		},
-		{
+		{ //nolint:gosec // test data
 			Proxy:  "login:password@127.0.0.1",
 			Output: "http://login:password@127.0.0.1:1080",
 		},
-		{
+		{ //nolint:gosec // test data
 			Proxy:        "login:password@127.0.0.1",
 			UserPassword: "something:else",
 			Output:       "http://login:password@127.0.0.1:1080",
@@ -978,12 +978,12 @@ func TestParseProxy(t *testing.T) {
 			UserPassword: "something:else",
 			Output:       "http://something:else@127.0.0.1:8888",
 		},
-		{
+		{ //nolint:gosec // test data
 			Proxy:        "user:password@127.0.0.1:8888",
 			UserPassword: "user2:password2",
 			Output:       "http://user:password@127.0.0.1:8888",
 		},
-		{
+		{ //nolint:gosec // test data
 			Proxy:        "http://user:password@127.0.0.1:8888",
 			UserPassword: "user2:password2",
 			Output:       "http://user:password@127.0.0.1:8888",

--- a/internal/geoipupdate/database/local_file_writer.go
+++ b/internal/geoipupdate/database/local_file_writer.go
@@ -184,7 +184,7 @@ func (w *fileWriter) close() error {
 		}
 	}
 
-	err := os.Remove(w.file.Name()) //nolint:gosec // path from os.CreateTemp
+	err := os.Remove(w.file.Name()) //nolint:gosec // path from config
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("removing temporary file: %w", err)
 	}
@@ -222,7 +222,7 @@ func (w *fileWriter) syncAndRename(name string) error {
 	if err := w.file.Close(); err != nil {
 		return fmt.Errorf("closing temporary file: %w", err)
 	}
-	if err := os.Rename(w.file.Name(), name); err != nil { //nolint:gosec // path from os.CreateTemp
+	if err := os.Rename(w.file.Name(), name); err != nil { //nolint:gosec // path from config
 		return fmt.Errorf("moving database into place: %w", err)
 	}
 	return nil

--- a/internal/geoipupdate/database/local_file_writer.go
+++ b/internal/geoipupdate/database/local_file_writer.go
@@ -184,7 +184,7 @@ func (w *fileWriter) close() error {
 		}
 	}
 
-	err := os.Remove(w.file.Name())
+	err := os.Remove(w.file.Name()) //nolint:gosec // path from os.CreateTemp
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("removing temporary file: %w", err)
 	}
@@ -222,7 +222,7 @@ func (w *fileWriter) syncAndRename(name string) error {
 	if err := w.file.Close(); err != nil {
 		return fmt.Errorf("closing temporary file: %w", err)
 	}
-	if err := os.Rename(w.file.Name(), name); err != nil {
+	if err := os.Rename(w.file.Name(), name); err != nil { //nolint:gosec // path from os.CreateTemp
 		return fmt.Errorf("moving database into place: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Add nolint directives for new gosec taint analysis false positives (G101, G703, G704, G706)
- These are false positives in a CLI tool where user-provided input (URLs, file paths, proxy credentials in tests) is used by design

## Test plan
- [x] `golangci-lint run ./...` passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)