### PR TITLE
Use 'GeoIP'/'GeoLite' branding in documentation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -167,7 +167,7 @@ nfpms:
     vendor: 'MaxMind, Inc.'
     homepage: https://www.maxmind.com/
     maintainer: 'MaxMind, Inc. <support@maxmind.com>'
-    description: Program to perform automatic updates of GeoIP2 and GeoLite2 binary databases.
+    description: Program to perform automatic updates of GeoIP and GeoLite binary databases.
     license: Apache 2.0 or MIT
     formats:
       - deb

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GeoIP Update
 
-The GeoIP Update program performs automatic updates of GeoIP and GeoLite
-binary databases. CSV databases are _not_ supported.
+The GeoIP Update program performs automatic updates of GeoIP and GeoLite binary
+databases. CSV databases are _not_ supported.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GeoIP Update
 
-The GeoIP Update program performs automatic updates of GeoIP2 and GeoLite2
+The GeoIP Update program performs automatic updates of GeoIP and GeoLite
 binary databases. CSV databases are _not_ supported.
 
 ## Installation

--- a/client/client.go
+++ b/client/client.go
@@ -11,7 +11,7 @@ import (
 //
 // After creation, it is valid for concurrent use.
 //
-
+//nolint:recvcheck // changing this would be a breaking change.
 type Client struct {
 	accountID  int
 	endpoint   string

--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,4 @@
-// Package client is a client for downloading GeoIP2 and GeoLite2 MMDB
+// Package client is a client for downloading GeoIP and GeoLite MMDB
 // databases.
 package client
 
@@ -7,11 +7,11 @@ import (
 	"net/http"
 )
 
-// Client downloads GeoIP2 and GeoLite2 MMDB databases.
+// Client downloads GeoIP and GeoLite MMDB databases.
 //
 // After creation, it is valid for concurrent use.
 //
-//nolint:recvcheck // changing this would be a breaking change.
+
 type Client struct {
 	accountID  int
 	endpoint   string

--- a/doc/GeoIP.conf.md
+++ b/doc/GeoIP.conf.md
@@ -5,7 +5,7 @@ GeoIP.conf - Configuration file for geoipupdate
 # SYNOPSIS
 
 This file allows you to configure your `geoipupdate` program to
-download GeoIP2 and GeoLite2 databases.
+download GeoIP and GeoLite databases.
 
 # DESCRIPTION
 
@@ -31,7 +31,7 @@ sensitive.
 
 :   List of space-separated database edition IDs. Edition IDs may consist
     of letters, digits, and dashes.  For example, `GeoIP2-City` would
-    download the GeoIP2 City database (`GeoIP2-City`). This can be overridden
+    download the GeoIP City database (`GeoIP2-City`). This can be overridden
     at run time by the `GEOIPUPDATE_EDITION_IDS` environment variable. Note:
     this was formerly called `ProductIds`.
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -16,7 +16,7 @@ An account ID, a license key, and edition ID(s) to update must be provided.
 2. Or they can be set via environment variables:
   * `GEOIPUPDATE_EDITION_IDS` - List of space-separated database edition
     IDs. Edition IDs may consist of letters, digits, and dashes. For
-    example. `GeoIP2-City` would download the GeoIP2 City database
+    example. `GeoIP2-City` would download the GeoIP City database
     (`GeoIP2-City`).
   * One of:
     * `GEOIPUPDATE_ACCOUNT_ID` - Your MaxMind account ID.

--- a/doc/geoipupdate.md
+++ b/doc/geoipupdate.md
@@ -1,6 +1,6 @@
 # NAME
 
-geoipupdate - GeoIP2 and GeoLite2 Update Program
+geoipupdate - GeoIP and GeoLite Update Program
 
 # SYNOPSIS
 
@@ -8,7 +8,7 @@ geoipupdate - GeoIP2 and GeoLite2 Update Program
 
 # DESCRIPTION
 
-`geoipupdate` automatically updates GeoIP2 and GeoLite2 databases. The
+`geoipupdate` automatically updates GeoIP and GeoLite databases. The
 program connects to the MaxMind GeoIP Update server to check for new
 databases. If a new database is available, the program will download and
 install it.
@@ -91,7 +91,7 @@ the MIT License, at your option.
 # MORE INFORMATION
 
 Visit [our website](https://www.maxmind.com/en/geoip2-services-and-databases)
-to learn more about the GeoIP2 databases or to sign up for a subscription.
+to learn more about the GeoIP databases or to sign up for a subscription.
 
 # SEE ALSO
 


### PR DESCRIPTION
Updates prose/documentation to refer to the products as "GeoIP"/"GeoLite" instead of "GeoIP2"/"GeoLite2". Technical identifiers (tool/binary names, edition IDs, filenames, the geolite.info hostname, URLs) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)